### PR TITLE
Add retry button for failed uploads

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -54,6 +54,22 @@ function showStatus(message, type) {
     }
 }
 
+// Display a retry button when an upload fails
+function showRetryButton() {
+    const container = document.getElementById('messageContainer');
+    if (!container) return;
+
+    const retryBtn = document.createElement('button');
+    retryBtn.textContent = 'Retry Upload';
+    retryBtn.className = 'btn btn-warning btn-sm ml-2';
+    retryBtn.addEventListener('click', () => {
+        retryBtn.disabled = true;
+        uploadFile();
+    });
+
+    container.appendChild(retryBtn);
+}
+
 function updateProgressBar(percentage, statusText) {
     const progressBar = document.getElementById('progressBar');
     const progressText = document.getElementById('progressText');
@@ -387,6 +403,7 @@ const uploadFile = async () => {
     } catch (error) {
         console.error('Upload error:', error);
         showStatus(`Upload failed: ${error.message}`, 'error');
+        showRetryButton();
     } finally {
         // Hide progress bar after a delay
         setTimeout(() => {

--- a/static/upload.js
+++ b/static/upload.js
@@ -76,6 +76,22 @@ function showStatus(message, type) {
     }
 }
 
+// Display a retry button when an upload fails
+function showRetryButton() {
+    const container = document.getElementById('messageContainer');
+    if (!container) return;
+
+    const retryBtn = document.createElement('button');
+    retryBtn.textContent = 'Retry Upload';
+    retryBtn.className = 'btn btn-warning btn-sm ml-2';
+    retryBtn.addEventListener('click', () => {
+        retryBtn.disabled = true;
+        uploadFile();
+    });
+
+    container.appendChild(retryBtn);
+}
+
 // Function to update progress bar
 function updateProgressBar(percentage, statusText) {
     const progressBar = document.getElementById('progressBar');
@@ -728,6 +744,7 @@ const uploadFile = async () => {
             } else {
                 cleanup();
                 showStatus(`Upload failed after ${uploadState.maxRetries} attempts: ${error.message}`, 'error');
+                showRetryButton();
             }
         };
 
@@ -879,5 +896,6 @@ const uploadFile = async () => {
     } catch (error) {
         console.error('Upload failed:', error);
         showStatus(`Upload failed: ${error.message}`, 'error');
+        showRetryButton();
     }
-}; 
+};


### PR DESCRIPTION
## Summary
- show a Retry Upload button when streaming upload errors
- provide same retry helper for the old WebSocket uploader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688bc62ee2648330955d7e26e308f543