### PR TITLE
Implement basic folder structure

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,7 +151,9 @@ def load_user(user_id):
 def home():
     try:
         user_database_id = uploader.get_user_database_id(current_user.id)
+        current_folder = request.args.get('folder', '/')
         files = []
+        folders = set()
         if user_database_id:
             # Ensure 'is_public' and 'salt' properties exist in the user's database
 
@@ -167,8 +169,10 @@ def home():
                     file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '') # Get filehash
                     # Only use file_data for file storage
                     file_data_files = properties.get('file_data', {}).get('files', [])
+                    folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
+                    folders.add(folder_path)
                     is_visible = properties.get('is_visible', {}).get('checkbox', True)
-                    if name and is_visible:
+                    if name and is_visible and folder_path == current_folder:
                         files.append({
                             "name": name,
                             "size": size,
@@ -176,12 +180,13 @@ def home():
                             "is_public": is_public,
                             "file_hash": file_hash,
                             "salted_hash": "",
-                            "file_data": file_data_files
+                            "file_data": file_data_files,
+                            "folder": folder_path
                         })
                 except Exception as e:
                     print(f"Error processing file data in home route: {e}")
                     continue
-        return render_template('home.html', files=files)
+        return render_template('home.html', files=files, folders=sorted(folders), current_folder=current_folder)
     except Exception as e:
         return f"Error loading home page: {str(e)}", 500
 
@@ -857,6 +862,24 @@ def toggle_public_access():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route('/update_file_metadata', methods=['POST'])
+@login_required
+def update_file_metadata():
+    try:
+        data = request.get_json()
+        file_id = data.get('file_id')
+        new_name = data.get('filename')
+        new_folder = data.get('folder_path')
+
+        if not file_id:
+            return jsonify({'error': 'file_id required'}), 400
+
+        uploader.update_file_metadata(file_id, filename=new_name, folder_path=new_folder)
+        return jsonify({'status': 'success'})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
 # ============================================================================
 # END FILE DOWNLOAD ROUTES
 # ============================================================================
@@ -879,6 +902,7 @@ def create_streaming_upload_session():
         filename = data.get('filename')
         file_size = data.get('fileSize')
         content_type = data.get('contentType', 'text/plain')  # Default to text/plain for Notion compatibility
+        folder_path = data.get('folderPath', '/')
         
         print(f"DEBUG: Creating session for {filename}, size: {file_size}")
         
@@ -899,7 +923,8 @@ def create_streaming_upload_session():
             filename=filename,
             file_size=file_size,
             user_database_id=user_database_id,
-            progress_callback=None  # Will use SocketIO for progress updates
+            progress_callback=None,  # Will use SocketIO for progress updates
+            folder_path=folder_path
         )
         
         print(f"DEBUG: Created upload session with ID: {upload_id}")

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -126,7 +126,8 @@ class StreamingFileUploader {
                 body: JSON.stringify({
                     filename: file.name,
                     fileSize: file.size,
-                    contentType: file.type || 'application/octet-stream'
+                    contentType: file.type || 'application/octet-stream',
+                    folderPath: window.currentFolder || '/'
                 })
             });
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,6 +5,18 @@
     <h1><i class="fas fa-cloud-upload-alt mr-2"></i>Upload Files</h1>
     <!-- Message container for notifications (will be filled dynamically) -->
     <div id="messageContainer"></div>
+    <div id="folderNav" class="mb-3">
+        <strong>Current Folder:</strong> {{ current_folder }}
+        {% if current_folder != '/' %}
+            {% set parent_folder = '/' + '/'.join(current_folder.strip('/').split('/')[:-1]) %}
+            <a href="{{ url_for('home', folder=parent_folder if parent_folder != '//' else '/') }}" class="ml-2">Back</a>
+        {% endif %}
+        <ul class="mt-2">
+            {% for f in folders %}
+                <li><a href="{{ url_for('home', folder=f) }}">{{ f }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
     <form id="uploadForm" method="post" enctype="multipart/form-data">
         <div class="form-group">
             <label for="fileInput">Select File:</label>
@@ -35,6 +47,7 @@
                     <tr>
                         <th><i class="fas fa-file mr-1"></i> Filename</th>
                         <th><i class="fas fa-weight mr-1"></i> Size</th>
+                        <th>Folder</th>
                         <th><i class="fas fa-link mr-1"></i> Public Link</th>
                         <th><i class="fas fa-lock-open mr-1"></i> Public Access</th>
                         <th><i class="fas fa-cogs mr-1"></i> Actions</th>
@@ -48,6 +61,7 @@
                             <strong>{{ file.name }}</strong>
                         </td>
                         <td class="filesize-cell">{{ file.size | format_bytes }}</td>
+                        <td>{{ file.folder }}</td>
                         <td>
                             {% if file.file_hash %}
                             <a href="{{ url_for('download_by_hash', salted_sha512_hash=file.file_hash) }}"
@@ -73,6 +87,12 @@
                                 class="btn btn-primary btn-sm">
                                 <i class="fas fa-download mr-1"></i>Download
                             </a>
+                            <button class="btn btn-secondary btn-sm rename-btn" data-file-id="{{ file.id }}">
+                                <i class="fas fa-edit mr-1"></i>Rename
+                            </button>
+                            <button class="btn btn-info btn-sm move-btn" data-file-id="{{ file.id }}">
+                                <i class="fas fa-folder-open mr-1"></i>Move
+                            </button>
                             <button class="btn btn-danger btn-sm delete-btn" data-file-id="{{ file.id }}">
                                 <i class="fas fa-trash-alt mr-1"></i>Delete
                             </button>
@@ -96,6 +116,7 @@
 <script>
     // Initialize socket connection
     const socket = io();
+    window.currentFolder = "{{ current_folder }}";
     // Set up event handlers when DOM is fully loaded
     document.addEventListener('DOMContentLoaded', function () {
         // Initialize streaming uploader
@@ -224,6 +245,34 @@
                     this.checked = !isPublic; // Revert toggle on error
                     showStatus('Error updating public status: ' + error.message, 'error');
                 }
+            });
+        });
+
+        document.querySelectorAll('.rename-btn').forEach(btn => {
+            btn.addEventListener('click', async function () {
+                const fileId = this.dataset.fileId;
+                const newName = prompt('New filename:');
+                if (!newName) return;
+                await fetch('/update_file_metadata', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({file_id: fileId, filename: newName})
+                });
+                location.reload();
+            });
+        });
+
+        document.querySelectorAll('.move-btn').forEach(btn => {
+            btn.addEventListener('click', async function () {
+                const fileId = this.dataset.fileId;
+                const newFolder = prompt('Move to folder:', window.currentFolder || '/');
+                if (newFolder === null) return;
+                await fetch('/update_file_metadata', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({file_id: fileId, folder_path: newFolder})
+                });
+                location.reload();
             });
         });
     });


### PR DESCRIPTION
## Summary
- add a `folder_path` field in Notion databases
- propagate folder path through uploader
- allow editing filename or folder from UI
- record current folder for uploads and navigation

## Testing
- `python -m py_compile app.py uploader/streaming_uploader.py uploader/notion_uploader.py`
- `pytest -q` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_b_688bdfcecee08330a3658d5a49f590b2