### PR TITLE
Implement folder entries with checkbox flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -904,6 +904,13 @@ def create_folder():
         if not user_database_id:
             return jsonify({'error': 'User database not found'}), 404
 
+        # Ensure the 'is_folder' property exists in the user's database
+        uploader.ensure_database_property(
+            user_database_id,
+            'is_folder',
+            'checkbox'
+        )
+
         uploader.create_folder(user_database_id, folder_name, parent_path)
         return jsonify({'status': 'success'})
     except Exception as e:

--- a/templates/home.html
+++ b/templates/home.html
@@ -57,13 +57,17 @@
                     <tr class="folder-row" data-folder-path="{{ entry.full_path }}">
                         <td>
                             <i class="fas fa-folder mr-1"></i>
-                            <a href="{{ url_for('home', folder=entry.full_path) }}"><strong>{{ entry.name }}</strong></a>
+                            <strong>{{ entry.name }}</strong>
                         </td>
                         <td class="filesize-cell">-</td>
                         <td>{{ entry.full_path }}</td>
                         <td></td>
                         <td></td>
-                        <td></td>
+                        <td>
+                            <a href="{{ url_for('home', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
+                                <i class="fas fa-folder-open mr-1"></i>Open
+                            </a>
+                        </td>
                     </tr>
                     {% else %}
                     <tr data-file-id="{{ entry.id }}" data-file-hash="{{ entry.file_hash }}">

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -1970,6 +1970,9 @@ class NotionFileUploader:
         """Add a file entry to a user's Notion database with enhanced ID validation"""
         url = f"{self.base_url}/pages"
 
+        # Ensure the is_folder property exists for this database
+        self.ensure_database_property(database_id, "is_folder", "checkbox")
+
         # CRITICAL FIX 1: Enhanced ID Validation and Logging
         print(f"🔍 ADD_FILE_TO_DB: Starting with file_upload_id: {file_upload_id}")
         print(f"🔍 ADD_FILE_TO_DB: Parameter types - file_upload_id: {type(file_upload_id)}, database_id: {type(database_id)}")
@@ -2055,6 +2058,9 @@ class NotionFileUploader:
                         }
                     }
                 ]
+            },
+            "is_folder": {
+                "checkbox": False
             }
         }
         # Add is_manifest property if this is a manifest entry


### PR DESCRIPTION
## Summary
- ensure `is_folder` property exists on folder creation
- allow uploading to set `is_folder` flag in database entries
- show button to open folders on home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_688c6194f460833091888abd8e94edf7