### PR TITLE
Improve folder deletion prompt

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -323,7 +323,18 @@
                 }
                 const data = await resp.json();
                 if (data.needs_confirm) {
-                    if (!confirm(`Folder is not empty. Delete ${data.count} items as well?`)) {
+                    let msg = `Folder is not empty. Delete ${data.file_count} file`;
+                    msg += data.file_count === 1 ? '' : 's';
+                    if (data.folder_count > 0) {
+                        msg += ` and ${data.folder_count} folder`;
+                        msg += data.folder_count === 1 ? '' : 's';
+                        if (data.subfolder_file_count > 0) {
+                            msg += ` containing ${data.subfolder_file_count} file`;
+                            msg += data.subfolder_file_count === 1 ? '' : 's';
+                        }
+                    }
+                    msg += ' as well?';
+                    if (!confirm(msg)) {
                         return;
                     }
                     resp = await fetch('/delete_folder', {


### PR DESCRIPTION
## Summary
- refine `delete_folder` API so confirmation only counts visible files
- show subfolder counts and visible file totals
- update delete folder confirmation message on the frontend

## Testing
- `python3 -m py_compile app.py uploader/*.py`

------
https://chatgpt.com/codex/tasks/task_b_688c74f8a7b883308dd3d7a642ebb115