### PR TITLE
Fix UI refresh after file upload

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -666,6 +666,11 @@ async function loadFiles() {
         // Set up event handlers for the new elements
         setupFileActionEventHandlers();
 
+        // Reinitialize file type icons for newly loaded content
+        if (typeof initializeFileTypeIcons === 'function') {
+            initializeFileTypeIcons();
+        }
+
         // Trigger content update event for modal system
         document.dispatchEvent(new CustomEvent('contentUpdated'));
 

--- a/static/upload.js
+++ b/static/upload.js
@@ -239,6 +239,11 @@ async function loadFiles() {
         // Add event listeners to the buttons
         setupFileActionEventHandlers();
 
+        // Reinitialize file type icons for dynamically loaded files
+        if (typeof initializeFileTypeIcons === 'function') {
+            initializeFileTypeIcons();
+        }
+
         console.log('File list refreshed successfully');
     } catch (error) {
         console.error('Error loading files:', error);


### PR DESCRIPTION
## Summary
- trigger icon reinitialization when reloading file list
- do this for regular and streaming upload JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688c765a9dc48330b4b3696032fceceb