### PR TITLE
Fix UI refresh after file upload

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -536,7 +536,8 @@ async function loadFiles() {
         console.log('🔍 DIAGNOSTIC: loadFiles() called from streaming upload');
         console.log('🔍 DIAGNOSTIC: Fetching file list from /api/files...');
 
-        const response = await fetch('/api/files');
+        const folderParam = encodeURIComponent(window.currentFolder || '/');
+        const response = await fetch(`/api/files?folder=${folderParam}`);
         if (!response.ok) {
             throw new Error('Failed to fetch file list');
         }
@@ -665,6 +666,11 @@ async function loadFiles() {
 
         // Set up event handlers for the new elements
         setupFileActionEventHandlers();
+
+        // Reinitialize file type icons for newly loaded content
+        if (typeof initializeFileTypeIcons === 'function') {
+            initializeFileTypeIcons();
+        }
 
         // Trigger content update event for modal system
         document.dispatchEvent(new CustomEvent('contentUpdated'));

--- a/static/upload.js
+++ b/static/upload.js
@@ -146,7 +146,8 @@ async function loadFiles() {
     try {
         console.log('Refreshing file list with AJAX...');
         // Fetch the file list data from the API
-        const response = await fetch('/files-api');
+        const folderParam = encodeURIComponent(window.currentFolder || '/');
+        const response = await fetch(`/files-api?folder=${folderParam}`);
         if (!response.ok) {
             throw new Error('Failed to fetch file list');
         }
@@ -238,6 +239,11 @@ async function loadFiles() {
 
         // Add event listeners to the buttons
         setupFileActionEventHandlers();
+
+        // Reinitialize file type icons for dynamically loaded files
+        if (typeof initializeFileTypeIcons === 'function') {
+            initializeFileTypeIcons();
+        }
 
         console.log('File list refreshed successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary
- trigger icon reinitialization when reloading file list
- do this for regular and streaming upload JS
- filter /api/files endpoints by folder so only current folder files are listed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_688c765a9dc48330b4b3696032fceceb