### PR TITLE
Fix file count in folder delete confirmation

### DIFF
--- a/app.py
+++ b/app.py
@@ -979,7 +979,7 @@ def delete_folder():
         if to_delete and not delete_contents:
             return jsonify({
                 'needs_confirm': True,
-                'file_count': file_count_root + file_count_subfolders,
+                'file_count': file_count_root,
                 'folder_count': len(subfolder_ids),
                 'subfolder_file_count': file_count_subfolders
             })


### PR DESCRIPTION
## Summary
- only count files directly in the folder when confirming folder deletion

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_688c7a91bb2c8330a4b70efcbee2f4af