### PR TITLE
Refresh file list using new entries API

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,9 +747,67 @@ def get_files_api():
             print(f"🔍 DIAGNOSTIC: First file in response: {formatted_files[0]}")
         
         return jsonify({'files': formatted_files})
-        
+
     except Exception as e:
         print(f"🚨 DIAGNOSTIC: Error in /api/files: {e}")
+        import traceback
+        traceback.print_exc()
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/entries')
+@login_required
+def get_entries_api():
+    """Return files and folders for the current user/folder (matches home route logic)."""
+    try:
+        user_database_id = uploader.get_user_database_id(current_user.id)
+        if not user_database_id:
+            return jsonify({'error': 'User database not found'}), 404
+
+        current_folder = request.args.get('folder', '/')
+        files_response = uploader.get_files_from_user_database(user_database_id)
+        files = files_response.get('results', [])
+
+        entries = []
+        for file_data in files:
+            try:
+                properties = file_data.get('properties', {})
+                name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+                size = properties.get('filesize', {}).get('number', 0)
+                file_id = file_data.get('id')
+                is_public = properties.get('is_public', {}).get('checkbox', False)
+                file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
+                folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
+                is_folder = properties.get('is_folder', {}).get('checkbox', False)
+                is_visible = properties.get('is_visible', {}).get('checkbox', True)
+
+                if name and is_visible and folder_path == current_folder:
+                    if is_folder:
+                        full_path = folder_path.rstrip('/') + '/' + name if folder_path != '/' else '/' + name
+                        entries.append({
+                            'type': 'folder',
+                            'name': name,
+                            'id': file_id,
+                            'full_path': full_path
+                        })
+                    else:
+                        entries.append({
+                            'type': 'file',
+                            'name': name,
+                            'size': size,
+                            'id': file_id,
+                            'is_public': is_public,
+                            'file_hash': file_hash,
+                            'folder': folder_path
+                        })
+            except Exception as e:
+                print(f"Error processing file data in get_entries_api: {e}")
+                continue
+
+        return jsonify({'entries': entries})
+
+    except Exception as e:
+        print(f"Error in /api/entries: {e}")
         import traceback
         traceback.print_exc()
         return jsonify({'error': str(e)}), 500


### PR DESCRIPTION
## Summary
- implement `/api/entries` to return files **and** folders
- update streaming upload script to load entries after upload
- attach folder delete actions when refreshing the table

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_688c7d2842a0833092eebaae2c0eb865