### PR TITLE
Use full-width layout and move file actions to dropdown

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -591,6 +591,7 @@ async function loadFiles() {
                         <tr>
                             <th><i class="fas fa-file mr-1"></i> Filename</th>
                             <th><i class="fas fa-weight mr-1"></i> Size</th>
+                            <th>Folder</th>
                             <th><i class="fas fa-link mr-1"></i> Public Link</th>
                             <th><i class="fas fa-lock-open mr-1"></i> Public Access</th>
                             <th><i class="fas fa-cogs mr-1"></i> Actions</th>
@@ -652,15 +653,16 @@ async function loadFiles() {
                         <a href="/d/${fileHash}" class="btn btn-primary btn-sm">
                             <i class="fas fa-download mr-1"></i>Download
                         </a>
-                        <button class="btn btn-secondary btn-sm rename-btn" data-file-id="${fileId}">
-                            <i class="fas fa-edit mr-1"></i>Rename
-                        </button>
-                        <button class="btn btn-info btn-sm move-btn" data-file-id="${fileId}">
-                            <i class="fas fa-folder-open mr-1"></i>Move
-                        </button>
-                        <button class="btn btn-danger btn-sm delete-btn" data-file-id="${fileId}" data-file-hash="${fileHash}">
-                            <i class="fas fa-trash-alt mr-1"></i>Delete
-                        </button>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="fas fa-bars"></i>
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <button type="button" class="dropdown-item rename-btn" data-file-id="${fileId}"><i class="fas fa-edit mr-1"></i>Rename</button>
+                                <button type="button" class="dropdown-item move-btn" data-file-id="${fileId}"><i class="fas fa-folder-open mr-1"></i>Move</button>
+                                <button type="button" class="dropdown-item delete-btn" data-file-id="${fileId}" data-file-hash="${fileHash}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                            </div>
+                        </div>
                     </td>
                 </tr>`;
             }

--- a/static/style.css
+++ b/static/style.css
@@ -29,15 +29,14 @@ h2 {
     font-size: 1.8em;
 }
 
-.container {
+.content-container {
     background: #1e1e1e;
     padding: 30px;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-    max-width: 1000px;
-    width: 90%;
+    width: 100%;
     box-sizing: border-box;
-    margin: 20px auto;
+    margin: 20px 0;
 }
 
 .form-group {

--- a/templates/base.html
+++ b/templates/base.html
@@ -119,7 +119,7 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark">
-        <div class="container">
+        <div class="container-fluid">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-cloud-upload-alt mr-2"></i><span style="color: #bb86fc;">Storage</span> Manager
             </a>
@@ -218,7 +218,7 @@
     </div>
     
     <footer class="footer mt-5">
-        <div class="container">
+        <div class="container-fluid">
             <p class="text-muted text-center">© 2025 Storage Manager</p>
         </div>
     </footer>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container-fluid content-container">
     <div class="row justify-content-center">
         <div class="col-md-6">
             <div class="auth-container">

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container-fluid content-container">
     <h1><i class="fas fa-cloud-upload-alt mr-2"></i>Upload Files</h1>
     <!-- Message container for notifications (will be filled dynamically) -->
     <div id="messageContainer"></div>
@@ -101,19 +101,19 @@
                             {% if entry.file_hash %}
                             <span class="view-button-container" data-filename="{{ entry.name }}" data-hash="{{ entry.file_hash }}" data-filesize="{{ entry.size | format_bytes }}"></span>
                             {% endif %}
-                            <a href="{{ url_for('download_by_hash', salted_sha512_hash=entry.file_hash) }}"
-                                class="btn btn-primary btn-sm">
+                            <a href="{{ url_for('download_by_hash', salted_sha512_hash=entry.file_hash) }}" class="btn btn-primary btn-sm">
                                 <i class="fas fa-download mr-1"></i>Download
                             </a>
-                            <button class="btn btn-secondary btn-sm rename-btn" data-file-id="{{ entry.id }}">
-                                <i class="fas fa-edit mr-1"></i>Rename
-                            </button>
-                            <button class="btn btn-info btn-sm move-btn" data-file-id="{{ entry.id }}">
-                                <i class="fas fa-folder-open mr-1"></i>Move
-                            </button>
-                            <button class="btn btn-danger btn-sm delete-btn" data-file-id="{{ entry.id }}">
-                                <i class="fas fa-trash-alt mr-1"></i>Delete
-                            </button>
+                            <div class="btn-group">
+                                <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-bars"></i>
+                                </button>
+                                <div class="dropdown-menu dropdown-menu-right">
+                                    <button type="button" class="dropdown-item rename-btn" data-file-id="{{ entry.id }}"><i class="fas fa-edit mr-1"></i>Rename</button>
+                                    <button type="button" class="dropdown-item move-btn" data-file-id="{{ entry.id }}"><i class="fas fa-folder-open mr-1"></i>Move</button>
+                                    <button type="button" class="dropdown-item delete-btn" data-file-id="{{ entry.id }}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                     {% endif %}
@@ -514,7 +514,7 @@
         white-space: nowrap;
     }
 
-    .action-buttons .btn {
+    .action-buttons > * {
         margin-right: 5px;
     }
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container-fluid content-container">
     <div class="row justify-content-center">
         <div class="col-md-6">
             <div class="auth-container">

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container-fluid content-container">
     <div class="row justify-content-center">
         <div class="col-md-6">
             <div class="auth-container">


### PR DESCRIPTION
## Summary
- Use fluid containers so pages and navigation span the full width
- Consolidate file actions into a dropdown "burger" menu
- Adjust styles and scripts to support new layout and action menu
- Ensure refreshed file list includes the Folder column after uploads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688e1f84e79883319623cb9113ca6132