### PR TITLE
Fix modal view button on iOS Safari

### DIFF
--- a/static/modal-lightbox.js
+++ b/static/modal-lightbox.js
@@ -846,9 +846,19 @@ function setupModalViewButtons() {
 
     const handleInteraction = (e) => {
         console.log('=== DEBUG: Click event triggered on:', e.target);
-        const viewButton = e.target.closest('.modal-view-btn') ||
-                           e.target.closest('a[href^="/v/"].btn-success') ||
-                           e.target.closest('.modal-view-link');
+
+        // Ensure we have an element to work with. Some browsers may fire
+        // events with a non-Element target (e.g. text nodes), which would
+        // cause errors when calling .closest().
+        let target = e.target;
+        if (!(target instanceof Element)) {
+            target = target.parentElement;
+        }
+        if (!target) {
+            return;
+        }
+
+        const viewButton = target.closest('.modal-view-btn, a[href^="/v/"].btn-success, .modal-view-link');
 
         if (!viewButton || !viewButton.href || !viewButton.href.includes('/v/')) {
             return;


### PR DESCRIPTION
## Summary
- Avoid calling `.closest()` on non-element event targets when handling media view buttons
- Ensure modal opens correctly on mobile browsers

## Testing
- `node --check static/modal-lightbox.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e321cbbc88331bd312c717658d3d9