### PR TITLE
Fix iOS portrait media viewer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -951,7 +951,8 @@ input:checked + .slider:before {
     }
     /* Ensure overlays never block upload controls in portrait mode */
     @media (orientation: portrait) {
-        .modal-overlay {
+        /* Only hide inactive overlays so media viewer works properly */
+        .modal-overlay:not(.show) {
             z-index: 1 !important;
             pointer-events: none !important;
             opacity: 0 !important;


### PR DESCRIPTION
## Summary
- ensure modal overlay is only hidden when not active so iOS Safari portrait can display media viewer

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e37e5b4248331ba8137e43c087312