### PR TITLE
Prevent duplicate usernames during registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,6 +256,12 @@ def register():
         username = request.form.get('username')
         password = request.form.get('password')
 
+        existing = uploader.query_user_database_by_username(
+            NOTION_USER_DB_ID, username
+        ).get('results', [])
+        if existing:
+            return "Benutzername bereits vergeben", 400
+
         # Hash password
         # Encode hash as base64 string for safe storage
         hashed_bytes = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())


### PR DESCRIPTION
## Summary
- query Notion user database to detect existing usernames before registration
- return a 400 error when a username is already taken

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b70c2c5c832f946426302237166c