### PR TITLE
feat: allow folder renaming

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -613,6 +613,9 @@ async function loadFiles() {
                         <a href="/?folder=${encodeURIComponent(entry.full_path)}" class="btn btn-primary btn-sm">
                             <i class="fas fa-folder-open mr-1"></i>Open
                         </a>
+                        <button class="btn btn-secondary btn-sm rename-folder-btn" data-folder-id="${entry.id}" data-folder-name="${entry.name}">
+                            <i class="fas fa-edit mr-1"></i>Rename
+                        </button>
                         <button class="btn btn-danger btn-sm delete-folder-btn" data-folder-id="${entry.id}" data-folder-path="${entry.full_path}">
                             <i class="fas fa-trash-alt mr-1"></i>Delete
                         </button>
@@ -970,8 +973,32 @@ function setupFileActionEventHandlers() {
     });
 }
 
-// Set up event handlers for folder actions (delete)
+// Set up event handlers for folder actions (rename, delete)
 function setupFolderActionEventHandlers() {
+    document.querySelectorAll('.rename-folder-btn').forEach(btn => {
+        btn.addEventListener('click', async function () {
+            const folderId = this.dataset.folderId;
+            const currentName = this.dataset.folderName || '';
+            const newName = prompt('New folder name:', currentName);
+            if (!newName) return;
+            try {
+                const resp = await fetch('/rename_folder', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ folder_id: folderId, new_name: newName })
+                });
+                if (!resp.ok) {
+                    alert('Failed to rename folder');
+                    return;
+                }
+                loadFiles();
+            } catch (error) {
+                console.error('Rename folder error:', error);
+                alert('Error renaming folder: ' + error.message);
+            }
+        });
+    });
+
     document.querySelectorAll('.delete-folder-btn').forEach(btn => {
         btn.addEventListener('click', async function () {
             const folderId = this.dataset.folderId;

--- a/templates/home.html
+++ b/templates/home.html
@@ -72,6 +72,9 @@
                             <a href="{{ url_for('home', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
                                 <i class="fas fa-folder-open mr-1"></i>Open
                             </a>
+                            <button class="btn btn-secondary btn-sm rename-folder-btn" data-folder-id="{{ entry.id }}" data-folder-name="{{ entry.name }}">
+                                <i class="fas fa-edit mr-1"></i>Rename
+                            </button>
                             <button class="btn btn-danger btn-sm delete-folder-btn" data-folder-id="{{ entry.id }}" data-folder-path="{{ entry.full_path }}">
                                 <i class="fas fa-trash-alt mr-1"></i>Delete
                             </button>
@@ -373,6 +376,21 @@
             });
             updateDeleteSelectedButton();
         }
+
+        document.querySelectorAll('.rename-folder-btn').forEach(btn => {
+            btn.addEventListener('click', async function () {
+                const folderId = this.dataset.folderId;
+                const currentName = this.dataset.folderName || '';
+                const newName = prompt('New folder name:', currentName);
+                if (!newName) return;
+                await fetch('/rename_folder', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({folder_id: folderId, new_name: newName})
+                });
+                location.reload();
+            });
+        });
 
         document.querySelectorAll('.delete-folder-btn').forEach(btn => {
             btn.addEventListener('click', async function () {


### PR DESCRIPTION
## Summary
- add `/rename_folder` endpoint that updates folder name and recursively adjusts nested paths
- allow folders to be renamed from the UI with new buttons
- wire client-side logic to call rename endpoint and refresh listing

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d24d8464832fb2888d6df5259f08