### PR TITLE
Style move file modal to match site theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1290,3 +1290,39 @@ tr[data-file-hash] .view-button-container .modal-view-link:hover::before {
         transition: transform 0.1s ease;
     }
 }
+
+/* Dark theme styling for move file modal */
+#moveModal .modal-content {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    border: 1px solid #bb86fc;
+}
+
+#moveModal .modal-header {
+    border-bottom: 1px solid #333;
+}
+
+#moveModal .modal-title {
+    color: #bb86fc;
+}
+
+#moveModal .close {
+    color: #e0e0e0;
+    text-shadow: none;
+}
+
+#moveModal .close:hover {
+    color: #bb86fc;
+}
+
+#moveModal .list-group-item {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    border: 1px solid #333;
+    cursor: pointer;
+}
+
+#moveModal .list-group-item:hover {
+    background-color: #2c2c2c;
+    color: #bb86fc;
+}


### PR DESCRIPTION
## Summary
- restyle file move modal with dark theme colors matching site
- add hover and header accents for move modal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987dc5d310832fbfd55ad86ca8cde6