### PR TITLE
Store multipart upload parts in root folder

### DIFF
--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -545,7 +545,8 @@ class NotionStreamingUploader:
                         salt=part_salt,
                         original_filename=filename,
                         file_url=file_url,
-                        folder_path=upload_session.get('folder_path', '/')
+                        # Store part entries at root to avoid orphaned parts when moving folders
+                        folder_path='/'
                     )
 
                     if self.notion_uploader.global_file_index_db_id:


### PR DESCRIPTION
## Summary
- Ensure split upload parts are always stored at root folder to prevent leftover hidden entries when moving or deleting folders.

## Testing
- `python -m py_compile uploader/streaming_uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_68989e00a7cc832fbd3e11610472325f