### PR TITLE
feat: upload multiple files and folders

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -23,8 +23,8 @@
     </div>
     <form id="uploadForm" method="post" enctype="multipart/form-data">
         <div class="form-group">
-            <label for="fileInput">Select File:</label>
-            <input type="file" id="fileInput" name="file" required>
+            <label for="fileInput">Select Files or Folders:</label>
+            <input type="file" id="fileInput" name="files" multiple webkitdirectory directory mozdirectory required>
         </div>
         <button type="submit" id="uploadButton" class="btn btn-primary">
             <i class="fas fa-upload mr-1"></i> Upload


### PR DESCRIPTION
## Summary
- allow selecting multiple files or entire folders in the upload form
- stream uploader now iterates over multiple files and passes computed folder paths
- server creates missing folder entries before starting a streaming upload

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899de67dab8832f923b8bdc2af5c9e6