### PR TITLE
Display aggregate folder sizes in UI

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -628,7 +628,7 @@ async function loadFiles() {
                 tableHTML += `
                 <tr class="folder-row" data-folder-path="${entry.full_path}">
                     <td><i class="fas fa-folder mr-1"></i><strong>${entry.name}</strong></td>
-                    <td class="filesize-cell">-</td>
+                    <td class="filesize-cell">${formatFileSize(entry.size)}</td>
                     <td>${entry.full_path}</td>
                     <td></td>
                     <td></td>

--- a/templates/home.html
+++ b/templates/home.html
@@ -69,7 +69,7 @@
                             <i class="fas fa-folder mr-1"></i>
                             <strong>{{ entry.name }}</strong>
                         </td>
-                        <td class="filesize-cell">-</td>
+                        <td class="filesize-cell">{{ entry.size | format_bytes }}</td>
                         <td>{{ entry.full_path }}</td>
                         <td></td>
                         <td></td>


### PR DESCRIPTION
## Summary
- compute cumulative file sizes for each folder and include in `home` and `/api/entries`
- show folder sizes in server-rendered table
- display folder sizes when refreshing file list via JavaScript

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e6bfbf6c832f89295cdf440bb2fe