### PR TITLE
Increase file part size to 1 GiB

### DIFF
--- a/notion_upload_split_plan.md
+++ b/notion_upload_split_plan.md
@@ -10,11 +10,11 @@
 
 
 ### 2.1. File Size Check and Splitting Logic
-- **Splitting threshold:** 250 MiB (262,144,000 bytes)
+- **Splitting threshold:** 1 GiB (1,073,741,824 bytes)
 - **Upload type threshold:** 20 MiB (20,971,520 bytes)
 
-- **If file > 250 MiB:**
-  1. **Split file** into parts, each ≤250 MiB (e.g., 260 MiB → 250 MiB part + 10 MiB part).
+- **If file > 1 GiB:**
+  1. **Split file** into parts, each ≤1 GiB (e.g., 1.2 GiB → 1 GiB part + 0.2 GiB part).
   2. **Upload each part:**
      - If part > 20 MiB: upload as multipart.
      - If part ≤ 20 MiB: upload as single-part.
@@ -29,14 +29,14 @@
        - `file`: set to the JSON file
 
   **Example:**
-  - For a 260 MiB file:
-    - Split into 250 MiB part and 10 MiB part
-    - 250 MiB part → upload as multipart
-    - 10 MiB part → upload as single-part
+  - For a 1.2 GiB file:
+    - Split into 1 GiB part and 0.2 GiB part
+    - 1 GiB part → upload as multipart
+    - 0.2 GiB part → upload as single-part
     - Each part gets its own DB entry with `is_visible` unchecked
     - After all parts, upload a JSON metadata file and create a DB entry with `is_visible` checked
 
-- **If file ≤ 250 MiB:**
+- **If file ≤ 1 GiB:**
   - If file > 20 MiB: upload as multipart
   - If file ≤ 20 MiB: upload as single-part
   - Create a single DB entry:

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -307,7 +307,7 @@ class NotionStreamingUploader:
       # Notion API constants
     SINGLE_PART_THRESHOLD = 20 * 1024 * 1024  # 20 MiB
     MULTIPART_CHUNK_SIZE = 5 * 1024 * 1024    # 5 MiB for multipart uploads
-    SPLIT_THRESHOLD = 250 * 1024 * 1024       # 250 MiB
+    SPLIT_THRESHOLD = 1024 * 1024 * 1024       # 1 GiB
 
     class _PartStream:
         """Iterator that yields exactly ``part_size`` bytes from ``stream_iter``.
@@ -505,7 +505,7 @@ class NotionStreamingUploader:
 
             if file_size > self.SPLIT_THRESHOLD:
                 # --- Stream large files in parts without buffering the entire part ---
-                print(f"INFO: File size > 250 MiB, splitting and uploading in parts...")
+                print(f"INFO: File size > 1 GiB, splitting and uploading in parts...")
 
                 total_parts = (file_size + self.SPLIT_THRESHOLD - 1) // self.SPLIT_THRESHOLD
                 last_part_size = file_size - self.SPLIT_THRESHOLD * (total_parts - 1)


### PR DESCRIPTION
## Summary
- Increase splitting threshold from 250 MiB to 1 GiB in the streaming uploader.
- Update splitting plan documentation to reflect the new 1 GiB part size.

## Testing
- `python -m py_compile uploader/streaming_uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_6899fd385a90832f82ea164fd18197f6