### PR TITLE
Lower file split threshold to 500 MiB

### DIFF
--- a/notion_upload_split_plan.md
+++ b/notion_upload_split_plan.md
@@ -10,11 +10,11 @@
 
 
 ### 2.1. File Size Check and Splitting Logic
-- **Splitting threshold:** 1 GiB (1,073,741,824 bytes)
+- **Splitting threshold:** 500 MiB (524,288,000 bytes)
 - **Upload type threshold:** 20 MiB (20,971,520 bytes)
 
-- **If file > 1 GiB:**
-  1. **Split file** into parts, each ≤1 GiB (e.g., 1.2 GiB → 1 GiB part + 0.2 GiB part).
+- **If file > 500 MiB:**
+  1. **Split file** into parts, each ≤500 MiB (e.g., 1.2 GiB → 500 MiB + 500 MiB + 0.2 GiB).
   2. **Upload each part:**
      - If part > 20 MiB: upload as multipart.
      - If part ≤ 20 MiB: upload as single-part.
@@ -30,13 +30,13 @@
 
   **Example:**
   - For a 1.2 GiB file:
-    - Split into 1 GiB part and 0.2 GiB part
-    - 1 GiB part → upload as multipart
+    - Split into two 500 MiB parts and one 0.2 GiB part
+    - Each 500 MiB part → upload as multipart
     - 0.2 GiB part → upload as single-part
     - Each part gets its own DB entry with `is_visible` unchecked
     - After all parts, upload a JSON metadata file and create a DB entry with `is_visible` checked
 
-- **If file ≤ 1 GiB:**
+- **If file ≤ 500 MiB:**
   - If file > 20 MiB: upload as multipart
   - If file ≤ 20 MiB: upload as single-part
   - Create a single DB entry:

--- a/static/upload.js
+++ b/static/upload.js
@@ -557,8 +557,8 @@ const uploadFile = async () => {
         uploadState.socket = io('/ws/upload', socketConfig);
         uploadState.socket.binaryType = 'arraybuffer';
 
-        // Determine if this is a large file (over 1GB)
-        const isLargeFile = fileSize > 1024 * 1024 * 1024;
+        // Determine if this is a large file (over 500MB)
+        const isLargeFile = fileSize > 500 * 1024 * 1024;
 
         // Chunk size and timing
         const chunkSize = 5 * 1024 * 1024; // 5MB chunks for Notion API

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -307,7 +307,7 @@ class NotionStreamingUploader:
       # Notion API constants
     SINGLE_PART_THRESHOLD = 20 * 1024 * 1024  # 20 MiB
     MULTIPART_CHUNK_SIZE = 5 * 1024 * 1024    # 5 MiB for multipart uploads
-    SPLIT_THRESHOLD = 1024 * 1024 * 1024       # 1 GiB
+    SPLIT_THRESHOLD = 500 * 1024 * 1024       # 500 MiB
 
     class _PartStream:
         """Iterator that yields exactly ``part_size`` bytes from ``stream_iter``.
@@ -505,7 +505,7 @@ class NotionStreamingUploader:
 
             if file_size > self.SPLIT_THRESHOLD:
                 # --- Stream large files in parts without buffering the entire part ---
-                print(f"INFO: File size > 1 GiB, splitting and uploading in parts...")
+                print(f"INFO: File size > 500 MiB, splitting and uploading in parts...")
 
                 total_parts = (file_size + self.SPLIT_THRESHOLD - 1) // self.SPLIT_THRESHOLD
                 last_part_size = file_size - self.SPLIT_THRESHOLD * (total_parts - 1)


### PR DESCRIPTION
## Summary
- reduce server-side SPLIT_THRESHOLD to 500MiB and adjust log message
- update frontend to flag uploads over 500MB
- refresh split documentation for new 500MiB limit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6bfbf4e4832fa28bc4e91c2a02dc