### PR TITLE
chore: adapt Dockerfile for qoddi deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ WORKDIR /app
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-ENV PORT=5000
+# Qoddi expects the application to listen on the PORT environment variable.
+# Set a default that matches Qoddi's standard port while still allowing an
+# override at runtime.
+ENV PORT=8080
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -30,12 +33,13 @@ RUN mkdir -p /app/uploads /app/static /app/templates
 # Set proper permissions
 RUN chmod -R 755 /app
 
-# Expose the port the app runs on
-EXPOSE 5000
+# Expose the port the app runs on for Qoddi
+EXPOSE 8080
 
-# Health check
+# Health check that respects the runtime port
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5000/ || exit 1
+    CMD curl -f http://localhost:$PORT/ || exit 1
 
 # Run the application using gunicorn with eventlet worker
-CMD ["gunicorn", "app:app", "--worker-class", "eventlet", "--workers", "1", "--bind", "0.0.0.0:5000", "--timeout", "300", "--keep-alive", "2"]
+# Use a shell form to allow environment variable expansion for the port.
+CMD ["sh", "-c", "gunicorn app:app --worker-class eventlet --workers 1 --bind 0.0.0.0:${PORT:-8080} --timeout 300 --keep-alive 2"]


### PR DESCRIPTION
## Summary
- configure Dockerfile to use PORT env variable for qoddi
- update health check and exposed port

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker build -t notion-storage .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3d188c4c832fb264296e3403a5ce