### PR TITLE
Align Flask app port with Docker configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -2150,3 +2150,7 @@ def process_websocket_chunk_robust(upload_id, part_number, chunk_data, is_last_c
 cleanup_old_sessions()
 
 # END OF STREAMING UPLOAD API
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 80))
+    socketio.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- Run the Flask-SocketIO app on the `PORT` environment variable so the container and Python app use the same port

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4698eb94832fbf684a2eda451a81