### PR TITLE
feat: parallelize small file uploads

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -439,21 +439,13 @@ const uploadFile = async () => {
         progressContainer.style.display = 'block';
     }
 
-    for (const file of files) {
-        updateProgressBar(0, 'Preparing upload...');
+    const MAX_PARALLEL_UPLOADS = 3;
+    const SMALL_FILE_LIMIT = 20 * 1024 * 1024; // 20 MiB
+    const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+    let totalBytesUploaded = 0;
+    const fileProgress = new Map();
 
-        const progressCallback = (progress, bytesUploaded) => {
-            updateProgressBar(
-                Math.floor(progress),
-                `Uploading: ${streamingUploader.formatFileSize(bytesUploaded)}/${streamingUploader.formatFileSize(file.size)}`
-            );
-        };
-
-        const statusCallback = (message, type) => {
-            showStatus(message, type);
-        };
-
-        // Determine target folder path for this file
+    const getFolderPath = (file) => {
         let folderPath = window.currentFolder || '/';
         if (file.webkitRelativePath) {
             const parts = file.webkitRelativePath.split('/');
@@ -464,16 +456,46 @@ const uploadFile = async () => {
                 folderPath = base === '/' ? `/${relativeFolder}`.replace(/\/\//g, '/') : `${base}${relativeFolder}`;
             }
         }
+        return folderPath;
+    };
 
-        try {
-            await streamingUploader.uploadFile(file, progressCallback, statusCallback, folderPath);
-            showStatus(`File "${file.name}" uploaded successfully!`, 'success');
-        } catch (error) {
-            console.error('Upload error:', error);
-            showStatus(`Upload failed: ${error.message}`, 'error');
-            showRetryButton();
-            break;
+    const createProgressCallback = (file) => {
+        return (progress, bytesUploaded) => {
+            const prev = fileProgress.get(file) || 0;
+            const delta = bytesUploaded - prev;
+            fileProgress.set(file, bytesUploaded);
+            totalBytesUploaded += delta;
+            const percentage = totalSize > 0 ? (totalBytesUploaded / totalSize) * 100 : 0;
+            updateProgressBar(
+                Math.floor(percentage),
+                `Uploading: ${streamingUploader.formatFileSize(totalBytesUploaded)}/${streamingUploader.formatFileSize(totalSize)}`
+            );
+        };
+    };
+
+    const uploadSingle = async (file) => {
+        const progressCallback = createProgressCallback(file);
+        const statusCallback = (message, type) => { showStatus(message, type); };
+        const folderPath = getFolderPath(file);
+        await streamingUploader.uploadFile(file, progressCallback, statusCallback, folderPath);
+        showStatus(`File "${file.name}" uploaded successfully!`, 'success');
+    };
+
+    const smallFiles = files.filter(f => f.size <= SMALL_FILE_LIMIT);
+    const largeFiles = files.filter(f => f.size > SMALL_FILE_LIMIT);
+
+    try {
+        for (let i = 0; i < smallFiles.length; i += MAX_PARALLEL_UPLOADS) {
+            const batch = smallFiles.slice(i, i + MAX_PARALLEL_UPLOADS).map(uploadSingle);
+            await Promise.all(batch);
         }
+        for (const file of largeFiles) {
+            await uploadSingle(file);
+        }
+    } catch (error) {
+        console.error('Upload error:', error);
+        showStatus(`Upload failed: ${error.message}`, 'error');
+        showRetryButton();
     }
 
     const uploadForm = document.getElementById('uploadForm');


### PR DESCRIPTION
## Summary
- upload up to three small files in parallel when each is <=20MiB
- track aggregate progress across concurrent uploads

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b8d28e1fc832fa762b7ac2107e86c