### PR TITLE
feat: parallelize small file uploads

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -109,7 +109,7 @@ input[type="password"]:focus {
     box-sizing: border-box;
 }
 
-#progressBarContainer {
+#progressBarContainer, .progress-bar-container {
     width: 100%;
     background-color: #333;
     border-radius: 5px;
@@ -117,7 +117,7 @@ input[type="password"]:focus {
     margin: 20px 0;
 }
 
-#progressBar {
+#progressBar, .progress-bar {
     width: 0%;
     height: 20px;
     background: linear-gradient(90deg, #bb86fc, #9d6fe7);
@@ -129,7 +129,7 @@ input[type="password"]:focus {
     justify-content: center;
 }
 
-#progressText {
+#progressText, .progress-text {
     color: #121212;
     font-size: 12px;
     font-weight: bold;
@@ -137,11 +137,15 @@ input[type="password"]:focus {
     z-index: 1;
 }
 
-#progressSubText {
+#progressSubText, .progress-subtext {
     text-align: center;
     font-size: 0.9em;
     color: #b0b0b0;
     margin-top: 5px;
+}
+
+#fileProgressContainer {
+    margin-top: 10px;
 }
 
 button,

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,14 +33,13 @@
         </button>
     </form>
 
-    <div id="progressBarContainer"
-        style="display: none; margin-top: 20px; width: 100%; background-color: #333; border-radius: 5px; padding: 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">
-        <div id="progressBar"
-            style="width: 0%; height: 24px; background-color: #bb86fc; border-radius: 4px; text-align: center; line-height: 24px; color: #121212; transition: width 0.3s;">
-            <span id="progressText" style="font-weight: bold;">0%</span>
+    <div id="progressBarContainer" class="progress-bar-container" style="display: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">
+        <div id="progressBar" class="progress-bar" style="height: 24px; line-height: 24px;">
+            <span id="progressText" class="progress-text" style="font-weight: bold;">0%</span>
         </div>
     </div>
-    <p id="progressSubText" style="text-align: center; font-size: 0.9em; color: #b0b0b0;"></p>
+    <p id="progressSubText" class="progress-subtext"></p>
+    <div id="fileProgressContainer"></div>
 
 
     <h2 style="margin-top: 40px;"><i class="fas fa-file-alt mr-2"></i>Your Files</h2>


### PR DESCRIPTION
## Summary
- upload up to three small files in parallel when each is <=20MiB
- track aggregate progress across concurrent uploads
- show individual progress bars for each file to avoid UI overwrites

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8d28e1fc832fa762b7ac2107e86c