### PR TITLE
Fix nested folder path joining

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -460,8 +460,12 @@ const uploadFile = async () => {
             parts.pop(); // remove filename
             const relativeFolder = parts.join('/');
             if (relativeFolder) {
-                const base = (window.currentFolder && window.currentFolder !== '/') ? window.currentFolder.replace(/\/$/, '/') : '/';
-                folderPath = base === '/' ? `/${relativeFolder}`.replace(/\/\//g, '/') : `${base}${relativeFolder}`;
+                // Ensure base path always ends with a single slash before appending subfolder
+                const base = (window.currentFolder && window.currentFolder !== '/')
+                    ? window.currentFolder.replace(/\/$/, '') + '/'
+                    : '/';
+                // Join base and relative folder, collapsing any accidental double slashes
+                folderPath = `${base}${relativeFolder}`.replace(/\/+/g, '/');
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure client-side folder uploads append a trailing slash to parent paths before adding subfolders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b962ccd78832f8ea2196b22b471c3