### PR TITLE
Prevent manifest creation on incomplete uploads

### DIFF
--- a/uploader/parallel_processor.py
+++ b/uploader/parallel_processor.py
@@ -137,7 +137,12 @@ class ParallelChunkProcessor:
                 buffer.seek(0)
                 final_data = buffer.read()
                 self._submit_chunk_upload_with_checkpoint(part_number, final_data, multipart_info, checkpoint_key, is_final=True)
-            
+
+            if bytes_received != self.upload_session['file_size']:
+                raise ValueError(
+                    f"Incomplete upload: expected {self.upload_session['file_size']} bytes, received {bytes_received}"
+                )
+
             print(f"📦 All chunks submitted ({part_number} parts), waiting for completion...")
             
             # Wait for all uploads to complete


### PR DESCRIPTION
## Summary
- verify incoming bytes for each part and overall size before finalizing manifest creation
- raise errors on partial single-part uploads to avoid incomplete files being marked complete
- ensure multipart processor aborts when stream ends early

## Testing
- `python -m py_compile uploader/streaming_uploader.py uploader/parallel_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6ff5484f4832fb07b1eb9f361b2db