### PR TITLE
Serve downloads via direct links and prefetch multipart segments

### DIFF
--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -254,7 +254,8 @@ class NotionFileUploader:
                 }
             return None
 
-        prefetch_count = int(os.getenv("STREAM_PREFETCH_COUNT", "1"))
+        # Prefetch multiple parts to minimize delays between 500MiB segments
+        prefetch_count = int(os.getenv("STREAM_PREFETCH_COUNT", "2"))
         prefetch_count = max(1, prefetch_count)
         streams: List[Tuple[queue.Queue, threading.Thread]] = []
 


### PR DESCRIPTION
## Summary
- Avoid proxying single-part downloads by redirecting clients straight to the signed storage URL
- Increase multipart streaming prefetch to minimize gaps between 500MiB parts

## Testing
- `python -m py_compile app.py uploader/notion_uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78de721e0832fa059de02d00dbb45