### PR TITLE
Wrap file downloads with Notion signed URLs

### DIFF
--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -188,7 +188,7 @@ class NotionFileUploader:
         if not manifest_url:
             raise Exception(f"No valid URL for manifest file on page {manifest_page_id}")
         # Download the manifest JSON
-        resp = requests.get(manifest_url)
+        resp = requests.get(manifest_url, headers=self._get_download_headers(manifest_url))
         resp.raise_for_status()
         manifest = resp.json() if resp.headers.get('content-type','').startswith('application/json') else json.loads(resp.content)
         parts = manifest.get('parts', [])
@@ -609,11 +609,14 @@ class NotionFileUploader:
             print(f"🔍 VALIDATING URL: Starting validation (expires in {int(time_until_expiry)}s)")
             
             # Use small range GET request instead of HEAD for better compatibility with Notion's CDN
-            headers = {
-                'Range': 'bytes=0-1',  # Request just first 2 bytes
-                'User-Agent': 'NotionUploader/1.0'
-            }
-            
+            headers = self._get_download_headers(
+                url,
+                {
+                    'Range': 'bytes=0-1',  # Request just first 2 bytes
+                    'User-Agent': 'NotionUploader/1.0',
+                },
+            )
+
             response = requests.get(
                 url,
                 headers=headers,
@@ -674,10 +677,60 @@ class NotionFileUploader:
         url, _, _ = self._fetch_fresh_download_url_with_metadata(page_id, original_filename)
         return url
 
+    def _convert_to_notion_signed_url(self, file_url: str, filename: str, file_id: str) -> str:
+        """Convert a direct S3 URL into a Notion signed download URL.
+
+        The Notion web client wraps S3 links with a special proxy URL of the form:
+        ``https://www.notion.so/signed/<encoded_s3_url>?id=<file_id>&table=block&spaceId=<space_id>&name=<filename>``.
+        Using this wrapper avoids AWS throttling seen with direct S3 links.
+
+        Args:
+            file_url: Direct S3 URL returned by Notion's API.
+            filename: Name of the file for the ``name`` query parameter.
+            file_id: Identifier supplied to the ``id`` query parameter. This is
+                typically the file block's ID, falling back to the page ID if the
+                file entry does not expose one.
+
+        Returns:
+            str: Notion signed URL if conversion is successful, otherwise the original URL.
+        """
+        try:
+            parsed = urllib.parse.urlparse(file_url)
+            base_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+            path_parts = parsed.path.strip('/').split('/')
+            if len(path_parts) < 1:
+                return file_url
+            space_id = path_parts[0]
+
+            encoded = urllib.parse.quote(base_url, safe='')
+            params = {
+                'id': file_id,
+                'table': 'block',
+                'spaceId': space_id,
+                'name': filename,
+            }
+            return f"https://www.notion.so/signed/{encoded}?{urllib.parse.urlencode(params)}"
+        except Exception:
+            return file_url
+
+    def _get_download_headers(self, url: str, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        """Build headers for downloading files from Notion."""
+        headers: Dict[str, str] = {}
+        if extra:
+            headers.update(extra)
+        try:
+            host = urllib.parse.urlparse(url).netloc
+        except Exception:
+            host = ""
+        if host.endswith("notion.so"):
+            headers["Authorization"] = f"Bearer {self.api_token}"
+            headers["Notion-Version"] = self.notion_version
+        return headers
+
     def _fetch_fresh_download_url_with_metadata(self, page_id: str, original_filename: str) -> tuple:
         """
         Fetch a fresh download URL from Notion API with file size and content type detection.
-        
+
         Returns:
             tuple: (download_url, file_size, content_type)
         """
@@ -708,6 +761,13 @@ class NotionFileUploader:
                 file_info = files_array[0]  # fallback to first if not found
 
             file_url = file_info.get('file', {}).get('url', '')
+
+            file_id = file_info.get('id') or page_id
+            file_url = self._convert_to_notion_signed_url(
+                file_url,
+                file_info.get('name', original_filename),
+                file_id,
+            )
 
             if not file_url:
                 print(f"No valid URL found in file_data property for page ID: {page_id}")
@@ -776,7 +836,10 @@ class NotionFileUploader:
                 download_url,
                 timeout=10,
                 allow_redirects=True,
-                headers={'User-Agent': 'NotionUploader/1.0'}
+                headers=self._get_download_headers(
+                    download_url,
+                    {'User-Agent': 'NotionUploader/1.0'},
+                ),
             )
             
             if response.status_code == 200:
@@ -2384,8 +2447,9 @@ class NotionFileUploader:
         if not notion_download_url:
             raise Exception(f"Could not find AWS S3 signed URL for file '{original_filename}' on page '{page_id}'")
         try:
-            # Use the download session without Notion headers for S3 requests
-            with self.download_session.get(notion_download_url, stream=True) as r:
+            headers = self._get_download_headers(notion_download_url)
+            # Use the download session; auth headers are added only for Notion proxy URLs
+            with self.download_session.get(notion_download_url, headers=headers, stream=True) as r:
                 r.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     yield chunk
@@ -2419,12 +2483,13 @@ class NotionFileUploader:
         notion_download_url = download_url or self.get_notion_file_url_from_page_property(page_id, original_filename)
         if not notion_download_url:
             raise Exception(f"Could not find AWS S3 signed URL for file '{original_filename}' on page '{page_id}'")
-        headers = {
-            'Range': f'bytes={start}-{end}'
-        }
+        headers = self._get_download_headers(
+            notion_download_url,
+            {'Range': f'bytes={start}-{end}'},
+        )
         print(f"Requesting bytes {start}-{end} from Notion S3 download URL: {notion_download_url}")
         try:
-            # Use the download session without Notion headers for S3 requests
+            # Use the download session; auth headers are added only for Notion proxy URLs
             with self.download_session.get(notion_download_url, headers=headers, stream=True) as r:
                 if r.status_code == 206:
                     print(f"Received partial content response (206) for range {start}-{end}")


### PR DESCRIPTION
## Summary
- Generate Notion signed proxy URLs from S3 links to avoid AWS throttling
- Use file entry IDs when constructing Notion proxy links, falling back to page IDs
- Send integration token when fetching Notion-signed URLs so downloads authenticate correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7cae4d6cc832f9736a1f0bb2868fa