### PR TITLE
feat: always fetch fresh download URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -189,22 +189,10 @@ uploader = NotionFileUploader(
 # Initialize streaming upload manager
 streaming_upload_manager = StreamingUploadManager(api_token=NOTION_API_TOKEN, socketio=socketio, notion_uploader=uploader)
 
-# Helper to retrieve download metadata with automatic refresh when needed
+# Helper to retrieve download metadata
 def fetch_download_metadata(page_id: str, filename: str) -> Dict[str, Any]:
-    """Fetch file download metadata and refresh if cached or throttled."""
-    metadata = uploader.get_file_download_metadata(page_id, filename)
-    if metadata.get('cached'):
-        # For repeated downloads, force a new signed URL
-        metadata = uploader.get_file_download_metadata(page_id, filename, force_refresh=True)
-    else:
-        try:
-            import requests
-            head_resp = requests.head(metadata['url'], timeout=5)
-            if head_resp.status_code in (403, 429):
-                metadata = uploader.get_file_download_metadata(page_id, filename, force_refresh=True)
-        except Exception:
-            metadata = uploader.get_file_download_metadata(page_id, filename, force_refresh=True)
-    return metadata
+    """Fetch fresh file download metadata without caching."""
+    return uploader.get_file_download_metadata(page_id, filename)
 
 # User class for Flask-Login
 class User(UserMixin):

--- a/config/resilient_upload_config.py
+++ b/config/resilient_upload_config.py
@@ -74,11 +74,6 @@ class ResilientUploadConfig:
             'pool_block': os.getenv('POOL_BLOCK', 'false').lower() == 'true'
         }
 
-        # Download URL cache configuration
-        # Allows adjusting how long signed download URLs are cached locally
-        # before requesting a fresh one from Notion. Defaults to 5 minutes.
-        self.download_url_cache_ttl = int(os.getenv('DOWNLOAD_URL_CACHE_TTL', '300'))
-        
         # Checkpoint Configuration
         self.checkpoint_config = {
             'enabled': os.getenv('CHECKPOINT_ENABLED', 'true').lower() == 'true',
@@ -147,7 +142,6 @@ class ResilientUploadConfig:
             'retry_config': self.retry_config,
             'circuit_breaker_config': self.circuit_breaker_config,
             'connection_config': self.connection_config,
-            'download_url_cache_ttl': self.download_url_cache_ttl,
             'checkpoint_config': self.checkpoint_config,
             'upload_limits': self.upload_limits,
             'monitoring_config': self.monitoring_config,
@@ -205,4 +199,3 @@ MAX_CONCURRENT_UPLOADS = resilient_config.upload_limits['max_concurrent_uploads'
 TIMEOUT_CONFIG = resilient_config.timeout_config
 RETRY_CONFIG = resilient_config.retry_config
 CHECKPOINT_ENABLED = resilient_config.checkpoint_config['enabled']
-DOWNLOAD_URL_CACHE_TTL = resilient_config.download_url_cache_ttl


### PR DESCRIPTION
## Summary
- always request fresh download metadata instead of using cached URLs
- remove download URL cache and related config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7d7dc05b4832f844d1223cdaf9008