### PR TITLE
Ensure fresh public status checks for shared files

### DIFF
--- a/app.py
+++ b/app.py
@@ -502,7 +502,7 @@ def download_by_hash(salted_sha512_hash):
     """
     try:
         # Find the file in the global file index using the hash
-        index_entry = uploader.get_file_by_salted_sha512_hash(salted_sha512_hash)
+        index_entry = uploader.get_file_by_salted_sha512_hash(salted_sha512_hash, force_refresh=True)
 
         if not index_entry:
             return "File not found", 404
@@ -662,7 +662,7 @@ def stream_by_hash(salted_sha512_hash):
     """
     try:
         # Find the file in the global file index using the hash
-        index_entry = uploader.get_file_by_salted_sha512_hash(salted_sha512_hash)
+        index_entry = uploader.get_file_by_salted_sha512_hash(salted_sha512_hash, force_refresh=True)
 
         if not index_entry:
             return "File not found", 404


### PR DESCRIPTION
## Summary
- Force download and streaming routes to refresh file metadata from Notion for each request
- Invalidate and bypass Global File Index cache after toggling public status

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a841c8db94832faf869e5f5f893e7a