### PR TITLE
Default Notion download chunk size to 1 MiB

### DIFF
--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -14,10 +14,10 @@ import random
 import mimetypes
 
 
-# Default chunk size for downloading files from Notion (5 MiB). Can be overridden
+# Default chunk size for downloading files from Notion (1 MiB). Can be overridden
 # by setting the ``DOWNLOAD_CHUNK_SIZE`` environment variable or by passing a
 # ``chunk_size`` parameter to streaming functions.
-DOWNLOAD_CHUNK_SIZE = int(os.getenv("DOWNLOAD_CHUNK_SIZE", 5 * 1024 * 1024))
+DOWNLOAD_CHUNK_SIZE = int(os.getenv("DOWNLOAD_CHUNK_SIZE", 1 * 1024 * 1024))
 
 class ChunkProcessor:
     def __init__(self, max_concurrent_uploads=3, max_pending_chunks=5):
@@ -2325,7 +2325,7 @@ class NotionFileUploader:
             download_url: Optional pre-fetched download URL. If provided, the
                 method will skip fetching a new URL from Notion.
             chunk_size: Size of chunks to download in bytes. Defaults to
-                ``DOWNLOAD_CHUNK_SIZE`` (5 MiB).
+                ``DOWNLOAD_CHUNK_SIZE`` (1 MiB).
 
         Yields:
             Iterator of file content chunks.
@@ -2361,7 +2361,7 @@ class NotionFileUploader:
             end: Ending byte position (inclusive).
             download_url: Optional pre-fetched download URL.
             chunk_size: Size of chunks to download in bytes. Defaults to
-                ``DOWNLOAD_CHUNK_SIZE`` (5 MiB).
+                ``DOWNLOAD_CHUNK_SIZE`` (1 MiB).
 
         Yields:
             Iterator of file content chunks for the requested range.


### PR DESCRIPTION
## Summary
- Set DOWNLOAD_CHUNK_SIZE to 1 MiB and update documentation
- Ensure stream_file_from_notion and stream_file_from_notion_range respect configurable chunk size

## Testing
- `python -m py_compile uploader/notion_uploader.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a860abab10832fb3a285cff9f9d8be