### PR TITLE
Add S3 downloader with configurable concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Notion Storage
+
+## Environment Variables
+
+### `MAX_S3_CONCURRENCY`
+Controls the maximum number of concurrent threads used for S3 downloads in
+`uploader.s3_downloader.download_file`. Defaults to `10` if unset.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv==1.0.0
 gunicorn
 eventlet
 psutil==5.9.8
+boto3

--- a/uploader/__init__.py
+++ b/uploader/__init__.py
@@ -1,3 +1,4 @@
 from .notion_uploader import NotionFileUploader
 from .chunk_processor import ChunkProcessor
 from .streaming_uploader import NotionStreamingUploader, StreamingUploadManager
+from .s3_downloader import download_file as download_s3_file

--- a/uploader/s3_downloader.py
+++ b/uploader/s3_downloader.py
@@ -1,0 +1,49 @@
+"""Utility for downloading objects from S3 with concurrency and retries.
+
+This module provides a ``download_file`` helper that wraps ``boto3``'s
+:class:`~boto3.s3.transfer.S3Transfer` to perform multipart downloads with
+configurable concurrency. Each part download is retried with exponential
+backoff to help recover from transient throttling errors.
+
+The maximum concurrency can be configured via the ``MAX_S3_CONCURRENCY``
+environment variable (default: ``10``).
+"""
+
+import os
+from typing import Optional
+
+import boto3
+from boto3.s3.transfer import S3Transfer, TransferConfig
+
+# Number of attempts for each part download (includes exponential backoff)
+_NUM_DOWNLOAD_ATTEMPTS = 5
+
+
+def download_file(bucket: str, key: str, dest: str, concurrency: Optional[int] = None) -> None:
+    """Download an object from S3 to ``dest``.
+
+    Parameters
+    ----------
+    bucket:
+        Name of the S3 bucket.
+    key:
+        Key of the object within the bucket.
+    dest:
+        Local filesystem path where the object should be stored.
+    concurrency:
+        Optional override for maximum concurrent S3 requests. If ``None``,
+        the value is read from the ``MAX_S3_CONCURRENCY`` environment variable
+        (default: ``10``).
+    """
+    if concurrency is None:
+        concurrency = int(os.getenv("MAX_S3_CONCURRENCY", "10"))
+
+    transfer_config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        max_concurrency=concurrency,
+        num_download_attempts=_NUM_DOWNLOAD_ATTEMPTS,
+    )
+
+    client = boto3.client("s3")
+    transfer = S3Transfer(client=client, config=transfer_config)
+    transfer.download_file(bucket, key, dest)


### PR DESCRIPTION
## Summary
- add S3 downloader utility built on boto3 S3Transfer with per-part backoff and configurable concurrency
- expose `MAX_S3_CONCURRENCY` environment variable and document it
- include boto3 dependency for the downloader

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8616dfbf4832fb21becd52913ab03