### PR TITLE
Ensure S3Transfer threads closed after downloads

### DIFF
--- a/uploader/s3_downloader.py
+++ b/uploader/s3_downloader.py
@@ -58,7 +58,12 @@ def download_file(bucket: str, key: str, dest: str, concurrency: Optional[int] =
         # Fallback to unsigned requests for publicly accessible objects
         anon_client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
         anon_transfer = S3Transfer(client=anon_client, config=transfer_config)
-        anon_transfer.download_file(bucket, key, dest)
+        try:
+            anon_transfer.download_file(bucket, key, dest)
+        finally:
+            anon_transfer.close()
+    finally:
+        transfer.close()
 
 
 def _parse_s3_url(url: str) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- Close `S3Transfer` instances in `download_file` to release worker threads
- Close anonymous S3Transfer in fallback when credentials are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c9a0a918832fb3f334c49eba0490