### PR TITLE
Clean up resources after S3 downloads

### DIFF
--- a/uploader/s3_downloader.py
+++ b/uploader/s3_downloader.py
@@ -59,6 +59,7 @@ _SESSION.mount(
         pool_connections=_MAX_S3_CONCURRENCY, pool_maxsize=_MAX_S3_CONCURRENCY
     ),
 )
+atexit.register(_SESSION.close)
 
 
 def _get_transfer(concurrency: int, *, anonymous: bool = False) -> S3Transfer:
@@ -179,6 +180,12 @@ class _PresignedStream:
         self.chunk_size = chunk_size
         self._resp: Optional[requests.Response] = None
         weakref.finalize(self, self.close)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
 
     def __iter__(self):
         for attempt in range(_NUM_DOWNLOAD_ATTEMPTS):


### PR DESCRIPTION
## Summary
- close global HTTP session at exit to release connection pool
- add context manager support to presigned stream so aborted downloads free resources

## Testing
- `pytest`
- `python -m py_compile uploader/s3_downloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9145b4210832f8b5062152d9b58b6