### PR TITLE
Add file search API and UI

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -44,6 +44,10 @@
 
 
     <h2 style="margin-top: 40px;"><i class="fas fa-file-alt mr-2"></i>Your Files</h2>
+    <div class="form-inline mb-3">
+        <input type="text" id="searchInput" class="form-control mr-2" placeholder="Search files...">
+        <button id="searchButton" class="btn btn-primary btn-sm"><i class="fas fa-search mr-1"></i>Search</button>
+    </div>
     <div id="files-container">
         <!-- Files will be loaded here via JavaScript or directly from Flask context -->
         {% if entries %}


### PR DESCRIPTION
## Summary
- add search input to home page
- provide `/api/files/search` endpoint to filter user files
- update client-side script to query search API and render results dynamically

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b41ab4beb8832f8ea47f1bbbc1e297