### PR TITLE
Add folder ZIP download route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gunicorn
 eventlet
 psutil==5.9.8
 boto3
+zipstream-new


### PR DESCRIPTION
## Summary
- add `/download_folder` route to stream a ZIP of files in a folder using existing Notion download helpers
- import zipstream and update requirements for streaming ZIP support

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b41bc00570832f8bc1c839309b657d