### PR TITLE
Add folder ZIP download route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gunicorn
 eventlet
 psutil==5.9.8
 boto3
+zipstream-new

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,6 +11,9 @@
             {% set parent_folder = '/' + '/'.join(current_folder.strip('/').split('/')[:-1]) %}
             <a href="{{ url_for('home', folder=parent_folder if parent_folder != '//' else '/') }}" class="ml-2">Back</a>
         {% endif %}
+        <a href="{{ url_for('download_folder', folder=current_folder) }}" class="btn btn-primary btn-sm ml-2">
+            <i class="fas fa-download mr-1"></i>Download Folder
+        </a>
         <button id="createFolderButton" class="btn btn-secondary btn-sm ml-2">
             <i class="fas fa-folder-plus mr-1"></i>Create Folder
         </button>
@@ -76,6 +79,9 @@
                         <td>
                             <a href="{{ url_for('home', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
                                 <i class="fas fa-folder-open mr-1"></i>Open
+                            </a>
+                            <a href="{{ url_for('download_folder', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
+                                <i class="fas fa-download mr-1"></i>Download
                             </a>
                             <button class="btn btn-secondary btn-sm rename-folder-btn" data-folder-id="{{ entry.id }}" data-folder-name="{{ entry.name }}">
                                 <i class="fas fa-edit mr-1"></i>Rename


### PR DESCRIPTION
## Summary
- add `/download_folder` route to stream a ZIP of files in a folder using existing Notion download helpers
- import zipstream and update requirements for streaming ZIP support
- add download buttons in the UI for current folder and each folder entry

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41bc00570832f8bc1c839309b657d