### PR TITLE
Add folder ZIP download route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv==1.0.0
 gunicorn
 eventlet
 psutil==5.9.8
+zipstream


### PR DESCRIPTION
## Summary
- stream folder downloads as ZIP archives
- lazily fetch download URLs while streaming
- add zipstream dependency

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b427aa8bdc832f873c6dac3f369007