### PR TITLE
Enable concurrent uploads with per-file progress bars

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -144,6 +144,42 @@ input[type="password"]:focus {
     margin-top: 5px;
 }
 
+/* Styles for multiple upload progress bars */
+.progress-item {
+    width: 100%;
+    background-color: #333;
+    border-radius: 5px;
+    padding: 3px;
+    margin: 20px 0;
+}
+
+.progress-bar {
+    width: 0%;
+    height: 20px;
+    background: linear-gradient(90deg, #bb86fc, #9d6fe7);
+    border-radius: 4px;
+    transition: width 0.3s ease-in-out;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.progress-text {
+    color: #121212;
+    font-size: 12px;
+    font-weight: bold;
+    text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.3);
+    z-index: 1;
+}
+
+.progress-subtext {
+    text-align: center;
+    font-size: 0.9em;
+    color: #b0b0b0;
+    margin-top: 5px;
+}
+
 button,
 .btn {
     padding: 10px 15px;

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,14 +36,7 @@
         </button>
     </form>
 
-    <div id="progressBarContainer"
-        style="display: none; margin-top: 20px; width: 100%; background-color: #333; border-radius: 5px; padding: 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">
-        <div id="progressBar"
-            style="width: 0%; height: 24px; background-color: #bb86fc; border-radius: 4px; text-align: center; line-height: 24px; color: #121212; transition: width 0.3s;">
-            <span id="progressText" style="font-weight: bold;">0%</span>
-        </div>
-    </div>
-    <p id="progressSubText" style="text-align: center; font-size: 0.9em; color: #b0b0b0;"></p>
+    <div id="progressBars" style="margin-top: 20px;"></div>
 
 
     <h2 style="margin-top: 40px;"><i class="fas fa-file-alt mr-2"></i>Your Files</h2>


### PR DESCRIPTION
## Summary
- Allow up to three files to upload simultaneously.
- Add per-file progress bars and styling for multiple concurrent uploads.
- Simplify home page progress UI to support multiple bars.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b434631b48832f8ac1c2204b0922bb