### PR TITLE
Wait for Notion finalization before refreshing files

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -205,15 +205,21 @@
                     progressSubText.textContent = `${uploadedFormatted} / ${totalFormatted}`;
                 }
             }
-        });
 
-        socket.on('upload_complete', function (data) {
-            console.log('Upload complete event received:', data);
-            updateProgressBar(100, 'Upload complete');
-            showStatus(`File uploaded successfully. ID: ${data.file_id}`, 'success');
-
-            // Refresh file list with a small delay to ensure server has updated
-            setTimeout(loadFiles, 500);
+            if (data.status === 'completed') {
+                updateProgressBar(100, 'Upload complete');
+                showStatus(`File uploaded successfully. ID: ${data.file_id}`, 'success');
+                if (data.upload_id && window.pendingUploads) {
+                    window.pendingUploads.delete(data.upload_id);
+                    if (window.pendingUploads.size === 0) {
+                        setTimeout(() => {
+                            if (typeof loadFiles === 'function') {
+                                loadFiles();
+                            }
+                        }, 500);
+                    }
+                }
+            }
         });
 
         // Add event handlers for delete buttons


### PR DESCRIPTION
## Summary
- track pending upload sessions on the client
- defer file list refresh until Notion database integration completes
- display a finalizing status while uploads are processed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b441e63488832fa10afc5e6367e78d