### PR TITLE
Add select all button for bulk file actions

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -142,11 +142,18 @@ function updateProgressBar(percentage, statusText) {
 // Bulk selection helpers
 const deleteSelectedBtn = document.getElementById('deleteSelectedButton');
 const moveSelectedBtn = document.getElementById('moveSelectedButton');
+const selectAllBtn = document.getElementById('selectAllButton');
 
 function updateBulkActionButtons() {
-    const anyChecked = document.querySelectorAll('.select-item:checked').length > 0;
+    const checkboxes = document.querySelectorAll('.select-item');
+    const checkedBoxes = document.querySelectorAll('.select-item:checked');
+    const anyChecked = checkedBoxes.length > 0;
     if (deleteSelectedBtn) deleteSelectedBtn.style.display = anyChecked ? 'inline-block' : 'none';
     if (moveSelectedBtn) moveSelectedBtn.style.display = anyChecked ? 'inline-block' : 'none';
+    if (selectAllBtn) {
+        const allChecked = checkboxes.length > 0 && checkedBoxes.length === checkboxes.length;
+        selectAllBtn.textContent = allChecked ? 'Deselect All' : 'Select All';
+    }
 }
 
 class StreamingFileUploader {
@@ -660,6 +667,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 searchBtn.click();
             }
         });
+    }
+
+    if (selectAllBtn && !selectAllBtn.dataset.listenerAdded) {
+        selectAllBtn.addEventListener('click', () => {
+            const checkboxes = document.querySelectorAll('.select-item');
+            const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+            checkboxes.forEach(cb => { cb.checked = !allChecked; });
+            updateBulkActionButtons();
+        });
+        selectAllBtn.dataset.listenerAdded = 'true';
     }
 });
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,6 +17,9 @@
         <button id="createFolderButton" class="btn btn-secondary btn-sm ml-2">
             <i class="fas fa-folder-plus mr-1"></i>Create Folder
         </button>
+        <button id="selectAllButton" class="btn btn-secondary btn-sm ml-2">
+            <i class="fas fa-check-square mr-1"></i>Select All
+        </button>
         <button id="deleteSelectedButton" class="btn btn-danger btn-sm ml-2" style="display: none;">
             <i class="fas fa-trash-alt mr-1"></i>Delete Selected
         </button>
@@ -344,11 +347,18 @@
 
         const deleteSelectedBtn = document.getElementById('deleteSelectedButton');
         const moveSelectedBtn = document.getElementById('moveSelectedButton');
+        const selectAllBtn = document.getElementById('selectAllButton');
 
         function updateBulkActionButtons() {
-            const anyChecked = document.querySelectorAll('.select-item:checked').length > 0;
+            const checkboxes = document.querySelectorAll('.select-item');
+            const checkedBoxes = document.querySelectorAll('.select-item:checked');
+            const anyChecked = checkedBoxes.length > 0;
             if (deleteSelectedBtn) deleteSelectedBtn.style.display = anyChecked ? 'inline-block' : 'none';
             if (moveSelectedBtn) moveSelectedBtn.style.display = anyChecked ? 'inline-block' : 'none';
+            if (selectAllBtn) {
+                const allChecked = checkboxes.length > 0 && checkedBoxes.length === checkboxes.length;
+                selectAllBtn.textContent = allChecked ? 'Deselect All' : 'Select All';
+            }
         }
 
         if (moveSelectedBtn) {
@@ -432,6 +442,16 @@
                 cb.addEventListener('change', updateBulkActionButtons);
             });
             updateBulkActionButtons();
+        }
+
+        if (selectAllBtn && !selectAllBtn.dataset.listenerAdded) {
+            selectAllBtn.addEventListener('click', function () {
+                const checkboxes = document.querySelectorAll('.select-item');
+                const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+                checkboxes.forEach(cb => { cb.checked = !allChecked; });
+                updateBulkActionButtons();
+            });
+            selectAllBtn.dataset.listenerAdded = 'true';
         }
 
         document.querySelectorAll('.rename-folder-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- Add Select All button to quickly choose every file or folder for bulk actions
- Update bulk selection logic to toggle all checkboxes and swap button text
- Hook button into global script for consistent behavior across dynamic updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f2e8b068832fad48f57e190e408c