### PR TITLE
Increase delete concurrency

### DIFF
--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -156,7 +156,7 @@ class NotionStreamingUploader:
                 return False
 
         if parts:
-            max_workers = min(5, len(parts))
+            max_workers = min(10, len(parts))
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = [executor.submit(_delete_part, part) for part in parts]
                 for future in concurrent.futures.as_completed(futures):
@@ -287,7 +287,7 @@ class NotionStreamingUploader:
                 return False
 
         if parts:
-            max_workers = min(5, len(parts))
+            max_workers = min(10, len(parts))
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = [executor.submit(_delete_part, part) for part in parts]
                 for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
## Summary
- allow deleting up to 10 manifest parts simultaneously for faster cleanup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f50505c0832f8e049696c951e58f