### PR TITLE
Refresh file list after each completed upload

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -214,14 +214,12 @@
                 showStatus(`File uploaded successfully. ID: ${data.file_id}`, 'success');
                 if (data.upload_id && window.pendingUploads) {
                     window.pendingUploads.delete(data.upload_id);
-                    if (window.pendingUploads.size === 0) {
-                        setTimeout(() => {
-                            if (typeof loadFiles === 'function') {
-                                loadFiles();
-                            }
-                        }, 500);
-                    }
                 }
+                setTimeout(() => {
+                    if (typeof loadFiles === 'function') {
+                        loadFiles();
+                    }
+                }, 500);
             }
         });
 


### PR DESCRIPTION
## Summary
- Update upload progress handler to refresh file list after every file is added to the database
- Maintain pending upload tracking while triggering list reload after each completion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f694a728832fa9806c9d51e0a41f