### PR TITLE
Add folder-path querying and lazy child retrieval

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ import random
 import string
 import json
 from flask_socketio import emit
-from collections import defaultdict
 import gc
 import zipstream
 
@@ -233,62 +232,52 @@ def home():
         entries = []
         next_cursor = None
         if user_database_id:
-            files_data = uploader.get_files_from_user_database(
+            files_data = uploader.query_children_by_folder_path(
                 user_database_id,
+                current_folder,
                 page_size=page_size,
                 start_cursor=start_cursor,
             )
             results = files_data.get('results', [])
             next_cursor = files_data.get('next_cursor')
 
-            # Pre-calculate cumulative sizes for all folders
-            folder_sizes = defaultdict(int)
-            for file_data in results:
+            def get_folder_size(path: str) -> int:
+                total = 0
                 try:
-                    properties = file_data.get('properties', {})
-                    name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-                    size = properties.get('filesize', {}).get('number', 0)
-                    folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
-                    is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                    is_visible = properties.get('is_visible', {}).get('checkbox', True)
-
-                    if name and is_visible and not is_folder:
-                        path = folder_path or '/'
-                        while True:
-                            folder_sizes[path] += size
-                            if path == '/' or path == '':
-                                break
-                            path = '/' + '/'.join(path.strip('/').split('/')[:-1])
-                            if path == '':
-                                path = '/'
+                    resp = uploader.query_children_by_folder_path(user_database_id, path)
+                    for item in resp.get('results', []):
+                        props = item.get('properties', {})
+                        if not props.get('is_visible', {}).get('checkbox', True):
+                            continue
+                        if props.get('is_folder', {}).get('checkbox', False):
+                            name = props.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+                            child_path = path.rstrip('/') + '/' + name if path != '/' else '/' + name
+                            total += get_folder_size(child_path)
+                        else:
+                            total += props.get('filesize', {}).get('number', 0)
                 except Exception as e:
-                    print(f"Error calculating folder sizes in home route: {e}")
-                    continue
+                    print(f"Error calculating folder size for {path}: {e}")
+                return total
 
-            # Build entries list including folder sizes
             for file_data in results:
                 try:
                     properties = file_data.get('properties', {})
-                    # The filename in title property is the original filename
                     name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
                     size = properties.get('filesize', {}).get('number', 0)
-                    file_id = file_data.get('id')  # Extract the Notion page ID
-                    is_public = properties.get('is_public', {}).get('checkbox', False)  # Get is_public status
-                    file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')  # Get filehash
-                    # Only use file_data for file storage
+                    file_id = file_data.get('id')
+                    is_public = properties.get('is_public', {}).get('checkbox', False)
+                    file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
                     file_data_files = properties.get('file_data', {}).get('files', [])
-                    folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
                     is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                    is_visible = properties.get('is_visible', {}).get('checkbox', True)
-                    if name and is_visible and folder_path == current_folder:
+                    if name:
                         if is_folder:
-                            full_path = folder_path.rstrip('/') + '/' + name if folder_path != '/' else '/' + name
+                            full_path = current_folder.rstrip('/') + '/' + name if current_folder != '/' else '/' + name
                             entries.append({
                                 "type": "folder",
                                 "name": name,
                                 "id": file_id,
                                 "full_path": full_path,
-                                "size": folder_sizes.get(full_path, 0)
+                                "size": get_folder_size(full_path),
                             })
                         else:
                             entries.append({
@@ -300,7 +289,7 @@ def home():
                                 "file_hash": file_hash,
                                 "salted_hash": "",
                                 "file_data": file_data_files,
-                                "folder": folder_path
+                                "folder": current_folder,
                             })
                 except Exception as e:
                     print(f"Error processing file data in home route: {e}")
@@ -522,40 +511,40 @@ def download_folder():
         if not user_database_id:
             return "User database not found", 404
 
-        files_data = uploader.get_files_from_user_database(user_database_id)
-        results = files_data.get('results', [])
-
-        prefix = folder_path.rstrip('/') + '/'
         files_to_zip = []
-        for entry in results:
-            props = entry.get('properties', {})
-            name = props.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-            is_folder = props.get('is_folder', {}).get('checkbox', False)
-            is_visible = props.get('is_visible', {}).get('checkbox', True)
-            is_manifest = props.get('is_manifest', {}).get('checkbox', False)
-            entry_path = props.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
 
-            if not name or is_folder or not is_visible:
-                continue
-            if entry_path != folder_path and not entry_path.startswith(prefix):
-                continue
+        def gather_files(path: str, rel_base: str = ''):
+            resp = uploader.query_children_by_folder_path(user_database_id, path)
+            for entry in resp.get('results', []):
+                props = entry.get('properties', {})
+                name = props.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+                is_folder = props.get('is_folder', {}).get('checkbox', False)
+                is_visible = props.get('is_visible', {}).get('checkbox', True)
+                is_manifest = props.get('is_manifest', {}).get('checkbox', False)
+                if not name or not is_visible:
+                    continue
+                if is_folder:
+                    child_path = path.rstrip('/') + '/' + name if path != '/' else '/' + name
+                    new_rel = os.path.join(rel_base, name) if rel_base else name
+                    gather_files(child_path, new_rel)
+                else:
+                    orig_name = (
+                        props.get('Original Filename', {})
+                        .get('title', [{}])[0]
+                        .get('text', {})
+                        .get('content', name)
+                    )
+                    files_to_zip.append(
+                        {
+                            'id': entry.get('id'),
+                            'name': name,
+                            'rel_path': rel_base,
+                            'is_manifest': is_manifest,
+                            'orig_name': orig_name,
+                        }
+                    )
 
-            rel_path = entry_path[len(folder_path):].lstrip('/') if entry_path.startswith(folder_path) else ''
-            orig_name = (
-                props.get('Original Filename', {})
-                .get('title', [{}])[0]
-                .get('text', {})
-                .get('content', name)
-            )
-            files_to_zip.append(
-                {
-                    'id': entry.get('id'),
-                    'name': name,
-                    'rel_path': rel_path,
-                    'is_manifest': is_manifest,
-                    'orig_name': orig_name,
-                }
-            )
+        gather_files(folder_path)
 
         z = zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED)
 
@@ -1089,8 +1078,9 @@ def get_files_api():
         current_folder = request.args.get('folder', '/')
         page_size = request.args.get('page_size', type=int)
         start_cursor = request.args.get('start_cursor')
-        files_response = uploader.get_files_from_user_database(
+        files_response = uploader.query_children_by_folder_path(
             user_database_id,
+            current_folder,
             page_size=page_size,
             start_cursor=start_cursor,
         )
@@ -1113,10 +1103,8 @@ def get_files_api():
             is_manifest = file_props.get('is_manifest', {}).get('checkbox', False)
             is_visible = file_props.get('is_visible', {}).get('checkbox', True)
             is_folder = file_props.get('is_folder', {}).get('checkbox', False)
-            folder_path = file_props.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
             salt = file_props.get('salt', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
 
-            # Compute salted hash for download link if salt is present
             salted_hash = file_hash
             if salt and file_hash:
                 import hashlib
@@ -1130,8 +1118,8 @@ def get_files_api():
             print(f"  - Is Public: {is_public} (needed for toggle state)")
             print(f"  - Size: {size}")
             print(f"  - Has all button data: {bool(file_id and file_hash is not None and is_public is not None)}")
-            
-            if is_visible and not is_folder and folder_path == current_folder:
+
+            if is_visible and not is_folder:
                 formatted_file = {
                     'id': file_id,
                     'name': name,
@@ -1167,37 +1155,32 @@ def get_entries_api():
         current_folder = request.args.get('folder', '/')
         page_size = request.args.get('page_size', type=int)
         start_cursor = request.args.get('start_cursor')
-        files_response = uploader.get_files_from_user_database(
+        files_response = uploader.query_children_by_folder_path(
             user_database_id,
+            current_folder,
             page_size=page_size,
             start_cursor=start_cursor,
         )
         files = files_response.get('results', [])
         next_cursor = files_response.get('next_cursor')
 
-        # Pre-calculate cumulative sizes for all folders
-        folder_sizes = defaultdict(int)
-        for file_data in files:
+        def get_folder_size(path: str) -> int:
+            total = 0
             try:
-                properties = file_data.get('properties', {})
-                name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-                size = properties.get('filesize', {}).get('number', 0)
-                folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
-                is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                is_visible = properties.get('is_visible', {}).get('checkbox', True)
-
-                if name and is_visible and not is_folder:
-                    path = folder_path or '/'
-                    while True:
-                        folder_sizes[path] += size
-                        if path == '/' or path == '':
-                            break
-                        path = '/' + '/'.join(path.strip('/').split('/')[:-1])
-                        if path == '':
-                            path = '/'
+                resp = uploader.query_children_by_folder_path(user_database_id, path)
+                for item in resp.get('results', []):
+                    props = item.get('properties', {})
+                    if not props.get('is_visible', {}).get('checkbox', True):
+                        continue
+                    if props.get('is_folder', {}).get('checkbox', False):
+                        name = props.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+                        child_path = path.rstrip('/') + '/' + name if path != '/' else '/' + name
+                        total += get_folder_size(child_path)
+                    else:
+                        total += props.get('filesize', {}).get('number', 0)
             except Exception as e:
                 print(f"Error calculating folder sizes in get_entries_api: {e}")
-                continue
+            return total
 
         entries = []
         for file_data in files:
@@ -1208,19 +1191,16 @@ def get_entries_api():
                 file_id = file_data.get('id')
                 is_public = properties.get('is_public', {}).get('checkbox', False)
                 file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-                folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                is_visible = properties.get('is_visible', {}).get('checkbox', True)
-
-                if name and is_visible and folder_path == current_folder:
+                if name:
                     if is_folder:
-                        full_path = folder_path.rstrip('/') + '/' + name if folder_path != '/' else '/' + name
+                        full_path = current_folder.rstrip('/') + '/' + name if current_folder != '/' else '/' + name
                         entries.append({
                             'type': 'folder',
                             'name': name,
                             'id': file_id,
                             'full_path': full_path,
-                            'size': folder_sizes.get(full_path, 0)
+                            'size': get_folder_size(full_path)
                         })
                     else:
                         entries.append({
@@ -1230,7 +1210,7 @@ def get_entries_api():
                             'id': file_id,
                             'is_public': is_public,
                             'file_hash': file_hash,
-                            'folder': folder_path
+                            'folder': current_folder
                         })
             except Exception as e:
                 print(f"Error processing file data in get_entries_api: {e}")
@@ -1243,6 +1223,13 @@ def get_entries_api():
         import traceback
         traceback.print_exc()
         return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/children')
+@login_required
+def get_children_api():
+    """Alias endpoint that fetches folder children on demand."""
+    return get_entries_api()
 
 
 @app.route('/api/files/search')
@@ -1316,20 +1303,19 @@ def list_folders_api():
         if not user_database_id:
             return jsonify({'error': 'User database not found'}), 404
 
-        files_response = uploader.get_files_from_user_database(user_database_id)
-        files = files_response.get('results', [])
+        folders: List[Dict[str, Any]] = []
 
-        folders = []
-        for file_data in files:
-            properties = file_data.get('properties', {})
-            is_folder = properties.get('is_folder', {}).get('checkbox', False)
-            if not is_folder:
-                continue
-            name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-            parent_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
-            full_path = parent_path.rstrip('/') + '/' + name if parent_path != '/' else '/' + name
-            folders.append({'id': file_data.get('id'), 'path': full_path})
+        def collect(path: str):
+            resp = uploader.query_children_by_folder_path(user_database_id, path)
+            for item in resp.get('results', []):
+                props = item.get('properties', {})
+                if props.get('is_folder', {}).get('checkbox', False):
+                    name = props.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+                    full_path = path.rstrip('/') + '/' + name if path != '/' else '/' + name
+                    folders.append({'id': item.get('id'), 'path': full_path})
+                    collect(full_path)
 
+        collect('/')
         folders.sort(key=lambda f: f['path'])
         folders.insert(0, {'id': None, 'path': '/'})
         return jsonify({'folders': folders})
@@ -1351,29 +1337,27 @@ def list_files_api():
             return jsonify({"error": "No user database ID found"}), 404
             
         current_folder = request.args.get('folder', '/')
-        # Query files from Notion database using uploader's method
-        files_data = uploader.get_files_from_user_database(user_database_id)
-        
-        # Format files for API response (matches old code format)
+        files_data = uploader.query_children_by_folder_path(user_database_id, current_folder)
+
         files = []
         for file_data in files_data.get('results', []):
             try:
                 properties = file_data.get('properties', {})
                 name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
                 size = properties.get('filesize', {}).get('number', 0)
-                file_id = file_data.get('id')  # Extract the Notion page ID
-                is_public = properties.get('is_public', {}).get('checkbox', False)  # Get is_public status
-                file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '') # Get filehash
+                file_id = file_data.get('id')
+                is_public = properties.get('is_public', {}).get('checkbox', False)
+                file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
 
-                if name and not is_folder and folder_path == current_folder:
+                if name and not is_folder:
                     files.append({
                         "name": name,
                         "size": size,
-                        "id": file_id,  # Add the file_id to the dictionary
-                        "is_public": is_public,  # Add is_public status
-                        "file_hash": file_hash  # Add file_hash
+                        "id": file_id,
+                        "is_public": is_public,
+                        "file_hash": file_hash,
+                        "folder": current_folder
                     })
             except Exception as e:
                 print(f"Error processing file data: {e}")

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -1218,28 +1218,44 @@ function setupFolderActionEventHandlers() {
 // Folder selection modal for moving files
 // =============================================
 let moveTargets = { fileIds: [], folderIds: [] };
+const folderCache = {};
+
+async function fetchFolderChildren(path) {
+    if (folderCache[path]) return folderCache[path];
+    const resp = await fetch(`/api/children?folder=${encodeURIComponent(path)}`);
+    const data = await resp.json();
+    folderCache[path] = data.entries || [];
+    return folderCache[path];
+}
+
+async function populateFolderList(path) {
+    const list = document.getElementById('folderList');
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (path !== '/') {
+        const parent = '/' + path.trim('/').split('/').slice(0, -1).join('/');
+        const back = document.createElement('li');
+        back.className = 'list-group-item back-item';
+        back.dataset.path = parent === '//' ? '/' : parent;
+        back.textContent = '..';
+        list.appendChild(back);
+    }
+
+    const entries = await fetchFolderChildren(path);
+    entries.filter(e => e.type === 'folder').forEach(entry => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item folder-option d-flex justify-content-between align-items-center';
+        li.dataset.path = entry.full_path;
+        li.innerHTML = `<span class="folder-name">${entry.name}</span>` +
+            `<button type="button" class="btn btn-link btn-sm expand-folder">▶</button>`;
+        list.appendChild(li);
+    });
+}
 
 async function openMoveDialog(fileIds = [], folderIds = []) {
     moveTargets = { fileIds, folderIds };
-    const list = document.getElementById('folderList');
-    if (!list) {
-        return;
-    }
-    list.innerHTML = '';
-    try {
-        const resp = await fetch('/api/folders');
-        const data = await resp.json();
-        (data.folders || []).forEach(folder => {
-            const li = document.createElement('li');
-            li.className = 'list-group-item folder-option';
-            li.textContent = folder.path;
-            li.dataset.path = folder.path;
-            list.appendChild(li);
-        });
-    } catch (error) {
-        console.error('🚨 DIAGNOSTIC: Error loading folders', error);
-        showStatus('Failed to load folders: ' + error.message, 'error');
-    }
+    await populateFolderList('/');
     $('#moveModal').modal('show');
 }
 
@@ -1247,6 +1263,19 @@ document.addEventListener('DOMContentLoaded', function () {
     const list = document.getElementById('folderList');
     if (list) {
         list.addEventListener('click', async function (e) {
+            const back = e.target.closest('.back-item');
+            if (back) {
+                await populateFolderList(back.dataset.path);
+                return;
+            }
+            const expandBtn = e.target.closest('.expand-folder');
+            if (expandBtn) {
+                const parent = expandBtn.closest('.folder-option');
+                if (parent) {
+                    await populateFolderList(parent.dataset.path);
+                }
+                return;
+            }
             const item = e.target.closest('.folder-option');
             if (!item) return;
             const path = item.dataset.path;


### PR DESCRIPTION
## Summary
- add `query_children_by_folder_path` helper to query Notion DB by folder path
- refactor Flask routes to use helper and expose `/api/children` for on-demand loading
- fetch folder children on demand in move dialog with client-side caching

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b712dbb440832fbb6cb73cb8b59585