### PR TITLE
Add server-side caching and incremental sync for file listings

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -135,6 +135,11 @@
                 </tbody>
             </table>
         </div>
+        <div id="loading-spinner" class="text-center my-3" style="display: {% if next_cursor %}block{% else %}none{% endif %};">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
         {% else %}
         <div class="alert alert-info text-center">
             <p><i class="fas fa-info-circle mr-2"></i>No files found. Upload your first file above.</p>
@@ -167,6 +172,7 @@
     // Initialize socket connection
     const socket = io();
     window.currentFolder = "{{ current_folder }}";
+    window.nextCursor = {{ next_cursor | tojson }};
     // Set up event handlers when DOM is fully loaded
     document.addEventListener('DOMContentLoaded', function () {
         // Initialize streaming uploader
@@ -211,6 +217,7 @@
 
             // Refresh file list with a small delay to ensure server has updated
             setTimeout(loadFiles, 500);
+            triggerCacheRefresh();
         });
 
         // Add event handlers for delete buttons
@@ -318,6 +325,10 @@
                 openMoveDialog([fileId], []);
             });
         });
+
+        if (window.nextCursor !== null) {
+            fetchMorePages();
+        }
 
         const createFolderBtn = document.getElementById('createFolderButton');
         if (createFolderBtn) {


### PR DESCRIPTION
## Summary
- add per-user in-memory cache with expiry and admin purge
- expose `/api/files/sync` and refresh endpoints
- progressively render file list and refresh cache after mutations

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b71bb410fc832f97e05a2e7a2e5cd7