### PR TITLE
feat: add per-user cache and incremental sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,13 +103,74 @@ socketio = SocketIO(
 app.upload_session_lock = threading.Lock()  # Master lock for upload session operations
 app.id_validation_lock = threading.Lock()   # Lock for ID validation operations
 
+# -------------------------------------------------------------
+# Simple in-memory cache for per-user file metadata
+# -------------------------------------------------------------
+from collections import OrderedDict
+
+CACHE_TTL = 600  # 10 minutes
+CACHE_MAX_USERS = 100
+_user_cache = OrderedDict()  # user_id -> {"data": ..., "timestamp": ...}
+
+def _purge_stale_cache():
+    """Remove expired cache entries and enforce size limit."""
+    now = time.time()
+    stale = [uid for uid, entry in _user_cache.items() if now - entry["timestamp"] > CACHE_TTL]
+    for uid in stale:
+        _user_cache.pop(uid, None)
+    while len(_user_cache) > CACHE_MAX_USERS:
+        _user_cache.popitem(last=False)
+
+def get_cached_files(user_database_id: str, force_refresh: bool = False):
+    """Retrieve Notion files for a user, using in-memory cache."""
+    _purge_stale_cache()
+    now = time.time()
+    entry = _user_cache.get(user_database_id)
+    if entry and not force_refresh and now - entry["timestamp"] < CACHE_TTL:
+        _user_cache.move_to_end(user_database_id)
+        return entry["data"], entry["timestamp"]
+
+    data = uploader.get_files_from_user_database(user_database_id)
+    _user_cache[user_database_id] = {"data": data, "timestamp": now}
+    _purge_stale_cache()
+    return data, now
+
+def refresh_cache_async(user_database_id: str):
+    """Refresh a user's cache in a background thread."""
+    def _refresh():
+        try:
+            get_cached_files(user_database_id, force_refresh=True)
+        except Exception as e:
+            print(f"Error refreshing cache for {user_database_id}: {e}")
+
+    threading.Thread(target=_refresh, daemon=True).start()
+
+
+@app.route('/api/cache/refresh', methods=['POST'])
+@login_required
+def refresh_cache_endpoint():
+    """Endpoint to trigger background cache refresh for current user."""
+    user_database_id = uploader.get_user_database_id(current_user.id)
+    if user_database_id:
+        refresh_cache_async(user_database_id)
+    return jsonify({'status': 'refreshing'})
+
+
+@app.route('/admin/cache/purge', methods=['POST'])
+@login_required
+def purge_cache_endpoint():
+    """Admin endpoint to purge stale cache entries."""
+    _purge_stale_cache()
+    return jsonify({'status': 'purged'})
+
+
 def ensure_folder_structure(user_database_id: str, folder_path: str):
     """Ensure that all folders in folder_path exist in the user's database."""
     try:
         if not folder_path or folder_path == '/':
             return
 
-        files_data = uploader.get_files_from_user_database(user_database_id)
+        files_data, _ = get_cached_files(user_database_id, force_refresh=True)
         existing_paths = set()
         for entry in files_data.get('results', []):
             props = entry.get('properties', {})
@@ -129,6 +190,68 @@ def ensure_folder_structure(user_database_id: str, folder_path: str):
             current = next_path
     except Exception as e:
         print(f"Error ensuring folder structure: {e}")
+
+def build_entries(results: List[Dict[str, Any]], current_folder: str) -> List[Dict[str, Any]]:
+    """Convert raw Notion results into UI-friendly entries for a folder."""
+    entries: List[Dict[str, Any]] = []
+    folder_sizes = defaultdict(int)
+    for file_data in results:
+        try:
+            properties = file_data.get('properties', {})
+            name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+            size = properties.get('filesize', {}).get('number', 0)
+            folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
+            is_folder = properties.get('is_folder', {}).get('checkbox', False)
+            is_visible = properties.get('is_visible', {}).get('checkbox', True)
+            if name and is_visible and not is_folder:
+                path = folder_path or '/'
+                while True:
+                    folder_sizes[path] += size
+                    if path == '/' or path == '':
+                        break
+                    path = '/' + '/'.join(path.strip('/').split('/')[:-1])
+                    if path == '':
+                        path = '/'
+        except Exception:
+            continue
+
+    for file_data in results:
+        try:
+            properties = file_data.get('properties', {})
+            name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+            size = properties.get('filesize', {}).get('number', 0)
+            file_id = file_data.get('id')
+            is_public = properties.get('is_public', {}).get('checkbox', False)
+            file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
+            file_data_files = properties.get('file_data', {}).get('files', [])
+            folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
+            is_folder = properties.get('is_folder', {}).get('checkbox', False)
+            is_visible = properties.get('is_visible', {}).get('checkbox', True)
+            if name and is_visible and folder_path == current_folder:
+                if is_folder:
+                    full_path = folder_path.rstrip('/') + '/' + name if folder_path != '/' else '/' + name
+                    entries.append({
+                        'type': 'folder',
+                        'name': name,
+                        'id': file_id,
+                        'full_path': full_path,
+                        'size': folder_sizes.get(full_path, 0)
+                    })
+                else:
+                    entries.append({
+                        'type': 'file',
+                        'name': name,
+                        'size': size,
+                        'id': file_id,
+                        'is_public': is_public,
+                        'file_hash': file_hash,
+                        'salted_hash': '',
+                        'file_data': file_data_files,
+                        'folder': folder_path
+                    })
+        except Exception:
+            continue
+    return entries
 
 def format_bytes(bytes, decimals=2):
     if bytes == 0:
@@ -228,76 +351,19 @@ def home():
     try:
         user_database_id = uploader.get_user_database_id(current_user.id)
         current_folder = request.args.get('folder', '/')
+        page_size = int(request.args.get('page_size', 50))
         entries = []
+        next_cursor = None
+        last_sync = 0
         if user_database_id:
-            files_data = uploader.get_files_from_user_database(user_database_id)
+            files_data, last_sync = get_cached_files(user_database_id)
             results = files_data.get('results', [])
-
-            # Pre-calculate cumulative sizes for all folders
-            folder_sizes = defaultdict(int)
-            for file_data in results:
-                try:
-                    properties = file_data.get('properties', {})
-                    name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-                    size = properties.get('filesize', {}).get('number', 0)
-                    folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
-                    is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                    is_visible = properties.get('is_visible', {}).get('checkbox', True)
-
-                    if name and is_visible and not is_folder:
-                        path = folder_path or '/'
-                        while True:
-                            folder_sizes[path] += size
-                            if path == '/' or path == '':
-                                break
-                            path = '/' + '/'.join(path.strip('/').split('/')[:-1])
-                            if path == '':
-                                path = '/'
-                except Exception as e:
-                    print(f"Error calculating folder sizes in home route: {e}")
-                    continue
-
-            # Build entries list including folder sizes
-            for file_data in results:
-                try:
-                    properties = file_data.get('properties', {})
-                    # The filename in title property is the original filename
-                    name = properties.get('filename', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-                    size = properties.get('filesize', {}).get('number', 0)
-                    file_id = file_data.get('id')  # Extract the Notion page ID
-                    is_public = properties.get('is_public', {}).get('checkbox', False)  # Get is_public status
-                    file_hash = properties.get('filehash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')  # Get filehash
-                    # Only use file_data for file storage
-                    file_data_files = properties.get('file_data', {}).get('files', [])
-                    folder_path = properties.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
-                    is_folder = properties.get('is_folder', {}).get('checkbox', False)
-                    is_visible = properties.get('is_visible', {}).get('checkbox', True)
-                    if name and is_visible and folder_path == current_folder:
-                        if is_folder:
-                            full_path = folder_path.rstrip('/') + '/' + name if folder_path != '/' else '/' + name
-                            entries.append({
-                                "type": "folder",
-                                "name": name,
-                                "id": file_id,
-                                "full_path": full_path,
-                                "size": folder_sizes.get(full_path, 0)
-                            })
-                        else:
-                            entries.append({
-                                "type": "file",
-                                "name": name,
-                                "size": size,
-                                "id": file_id,
-                                "is_public": is_public,
-                                "file_hash": file_hash,
-                                "salted_hash": "",
-                                "file_data": file_data_files,
-                                "folder": folder_path
-                            })
-                except Exception as e:
-                    print(f"Error processing file data in home route: {e}")
-                    continue
-        return render_template('home.html', entries=entries, current_folder=current_folder)
+            all_entries = build_entries(results, current_folder)
+            entries = all_entries[:page_size]
+            if len(all_entries) > page_size:
+                next_cursor = page_size
+            refresh_cache_async(user_database_id)
+        return render_template('home.html', entries=entries, current_folder=current_folder, next_cursor=next_cursor, cache_timestamp=last_sync)
     except Exception as e:
         return f"Error loading home page: {str(e)}", 500
 
@@ -478,7 +544,7 @@ def download_file(filename):
         if not user_database_id:
             return "User database not found", 404
 
-        files_data = uploader.get_files_from_user_database(user_database_id)
+        files_data, _ = get_cached_files(user_database_id)
         file_hash = None
         manifest_page_id = None
         for file_data in files_data.get('results', []):
@@ -509,7 +575,7 @@ def download_folder():
         if not user_database_id:
             return "User database not found", 404
 
-        files_data = uploader.get_files_from_user_database(user_database_id)
+        files_data, _ = get_cached_files(user_database_id)
         results = files_data.get('results', [])
 
         prefix = folder_path.rstrip('/') + '/'
@@ -1074,7 +1140,7 @@ def get_files_api():
             return jsonify({'error': 'User database not found'}), 404
         
         current_folder = request.args.get('folder', '/')
-        files_response = uploader.get_files_from_user_database(user_database_id)
+        files_response, _ = get_cached_files(user_database_id)
         files = files_response.get('results', [])
         
         print(f"🔍 DIAGNOSTIC: Raw files from database: {len(files)} files")
@@ -1145,7 +1211,7 @@ def get_entries_api():
             return jsonify({'error': 'User database not found'}), 404
 
         current_folder = request.args.get('folder', '/')
-        files_response = uploader.get_files_from_user_database(user_database_id)
+        files_response, _ = get_cached_files(user_database_id)
         files = files_response.get('results', [])
 
         # Pre-calculate cumulative sizes for all folders
@@ -1218,6 +1284,28 @@ def get_entries_api():
         return jsonify({'error': str(e)}), 500
 
 
+@app.route('/api/files/sync')
+@login_required
+def sync_files_api():
+    """Return incremental file data using cursor and since parameters."""
+    user_database_id = uploader.get_user_database_id(current_user.id)
+    if not user_database_id:
+        return jsonify({'error': 'User database not found'}), 404
+    cursor = request.args.get('cursor', type=int, default=0)
+    page_size = request.args.get('page_size', type=int, default=50)
+    folder = request.args.get('folder', '/')
+    since = request.args.get('since', type=float)
+    files_data, last_sync = get_cached_files(user_database_id)
+    if since and since >= last_sync:
+        return jsonify({'results': [], 'next_cursor': None, 'last_sync': last_sync})
+    results = files_data.get('results', [])
+    entries = build_entries(results, folder)
+    start = cursor
+    end = min(start + page_size, len(entries))
+    next_cursor = end if end < len(entries) else None
+    return jsonify({'results': entries[start:end], 'next_cursor': next_cursor, 'last_sync': last_sync})
+
+
 @app.route('/api/files/search')
 @login_required
 def search_files_api():
@@ -1228,7 +1316,7 @@ def search_files_api():
             return jsonify({'error': 'User database not found'}), 404
 
         query = request.args.get('q', '').lower()
-        files_response = uploader.get_files_from_user_database(user_database_id)
+        files_response, _ = get_cached_files(user_database_id)
         files = files_response.get('results', [])
 
         entries = []
@@ -1289,7 +1377,7 @@ def list_folders_api():
         if not user_database_id:
             return jsonify({'error': 'User database not found'}), 404
 
-        files_response = uploader.get_files_from_user_database(user_database_id)
+        files_response, _ = get_cached_files(user_database_id)
         files = files_response.get('results', [])
 
         folders = []
@@ -1324,8 +1412,7 @@ def list_files_api():
             return jsonify({"error": "No user database ID found"}), 404
             
         current_folder = request.args.get('folder', '/')
-        # Query files from Notion database using uploader's method
-        files_data = uploader.get_files_from_user_database(user_database_id)
+        files_data, _ = get_cached_files(user_database_id)
         
         # Format files for API response (matches old code format)
         files = []
@@ -1510,7 +1597,7 @@ def rename_folder():
         uploader.update_file_metadata(folder_id, filename=new_name)
 
         # Update paths for items inside the folder
-        all_entries = uploader.get_files_from_user_database(user_database_id)
+        all_entries, _ = get_cached_files(user_database_id, force_refresh=True)
         prefix = old_full_path + '/'
         for entry in all_entries.get('results', []):
             entry_id = entry.get('id')
@@ -1556,7 +1643,7 @@ def delete_folder():
 
         folder_path = parent_path.rstrip('/') + '/' + folder_name if parent_path != '/' else '/' + folder_name
 
-        all_entries = uploader.get_files_from_user_database(user_database_id)
+        all_entries, _ = get_cached_files(user_database_id, force_refresh=True)
         to_delete = []
 
         file_count_root = 0
@@ -1631,7 +1718,7 @@ def delete_selected():
         if not user_database_id:
             return jsonify({'error': 'User database not found'}), 404
 
-        all_entries = uploader.get_files_from_user_database(user_database_id)
+        all_entries, _ = get_cached_files(user_database_id, force_refresh=True)
 
         if preview:
             selected_file_ids = set(file_ids)
@@ -1742,7 +1829,7 @@ def move_selected():
 
         all_entries = None
         if folder_ids:
-            all_entries = uploader.get_files_from_user_database(user_database_id)
+            all_entries, _ = get_cached_files(user_database_id, force_refresh=True)
 
         for folder_id in folder_ids:
             try:

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -156,6 +156,81 @@ function updateBulkActionButtons() {
     }
 }
 
+function formatBytes(bytes) {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1000;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+function refreshServerCache() {
+    fetch('/api/cache/refresh', { method: 'POST' }).catch(() => {});
+}
+
+async function fetchRemainingEntries() {
+    const spinner = document.getElementById('loadingSpinner');
+    while (window.nextCursor !== null && window.nextCursor !== undefined) {
+        if (spinner) spinner.style.display = 'block';
+        const params = new URLSearchParams({
+            cursor: window.nextCursor,
+            folder: window.currentFolder || '/',
+            since: window.cacheTimestamp || 0
+        });
+        const resp = await fetch(`/api/files/sync?${params.toString()}`);
+        if (!resp.ok) break;
+        const data = await resp.json();
+        window.cacheTimestamp = data.last_sync;
+        if (Array.isArray(data.results) && data.results.length) {
+            appendEntries(data.results);
+        }
+        window.nextCursor = data.next_cursor;
+        if (window.nextCursor == null && spinner) spinner.style.display = 'none';
+    }
+}
+
+function appendEntries(entries) {
+    if (!window.cachedEntries) window.cachedEntries = [];
+    window.cachedEntries = window.cachedEntries.concat(entries);
+    const tbody = document.querySelector('#files-container tbody');
+    if (!tbody) return;
+    entries.forEach(entry => {
+        let row = document.createElement('tr');
+        if (entry.type === 'folder') {
+            row.className = 'folder-row';
+            row.dataset.folderPath = entry.full_path;
+            row.innerHTML = `
+                <td><input type="checkbox" class="select-item" data-type="folder" data-id="${entry.id}"></td>
+                <td><i class="fas fa-folder mr-1"></i><strong>${entry.name}</strong></td>
+                <td class="filesize-cell">${formatBytes(entry.size)}</td>
+                <td>${entry.full_path}</td>
+                <td></td>
+                <td></td>
+                <td><a href="/?folder=${encodeURIComponent(entry.full_path)}" class="btn btn-primary btn-sm"><i class="fas fa-folder-open mr-1"></i>Open</a></td>`;
+        } else {
+            row.dataset.fileId = entry.id;
+            row.dataset.fileHash = entry.file_hash || '';
+            const link = entry.file_hash ? `<a href="/d/${entry.file_hash}" target="_blank" class="public-link"><i class="fas fa-external-link-alt mr-1"></i>${location.origin}/d/${entry.file_hash.slice(0,10)}...</a>` : '<span class="text-muted">N/A</span>';
+            row.innerHTML = `
+                <td><input type="checkbox" class="select-item" data-type="file" data-id="${entry.id}"></td>
+                <td><span class="file-type-icon" data-filename="${entry.name}"></span><strong>${entry.name}</strong></td>
+                <td class="filesize-cell">${formatBytes(entry.size)}</td>
+                <td>${entry.folder}</td>
+                <td>${link}</td>
+                <td><label class="switch"><input type="checkbox" class="public-toggle" data-file-id="${entry.id}" data-file-hash="${entry.file_hash || ''}" ${entry.is_public ? 'checked' : ''}><span class="slider round"></span></label></td>
+                <td class="action-buttons"><a href="/d/${entry.file_hash}" class="btn btn-primary btn-sm"><i class="fas fa-download mr-1"></i>Download</a></td>`;
+        }
+        tbody.appendChild(row);
+    });
+    if (typeof initializeFileTypeIcons === 'function') {
+        initializeFileTypeIcons();
+    }
+    setupFileActionEventHandlers();
+    setupFolderActionEventHandlers();
+    document.querySelectorAll('.select-item').forEach(cb => cb.addEventListener('change', updateBulkActionButtons));
+    updateBulkActionButtons();
+}
+
 class StreamingFileUploader {
     constructor() {
         this.activeUploads = new Map();
@@ -678,6 +753,11 @@ document.addEventListener('DOMContentLoaded', function () {
         });
         selectAllBtn.dataset.listenerAdded = 'true';
     }
+    document.querySelectorAll('.select-item').forEach(cb => cb.addEventListener('change', updateBulkActionButtons));
+    updateBulkActionButtons();
+    if (window.nextCursor !== null && window.nextCursor !== undefined) {
+        fetchRemainingEntries();
+    }
 });
 
 // Function to refresh file list - WITH DIAGNOSTIC LOGGING
@@ -700,6 +780,7 @@ async function loadFiles() {
         }
 
         renderEntries(data.entries);
+        refreshServerCache();
     } catch (error) {
         console.error('🚨 DIAGNOSTIC: Error loading files:', error);
         showStatus('Failed to refresh file list: ' + error.message, 'error');
@@ -1034,6 +1115,7 @@ function setupFileActionEventHandlers() {
                 if (responseData.status === 'success') {
                     this.closest('tr').remove();
                     showStatus('File deleted successfully', 'success');
+                    refreshServerCache();
 
                     // Check if there are any remaining files
                     if (document.querySelectorAll('#fileTable tbody tr').length === 0) {
@@ -1104,6 +1186,7 @@ function setupFileActionEventHandlers() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ file_id: fileId, filename: newName })
             });
+            refreshServerCache();
             location.reload();
         });
     });
@@ -1237,6 +1320,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         body: JSON.stringify({ file_ids: moveTargets.fileIds, folder_ids: moveTargets.folderIds, destination: path })
                     });
                 }
+                refreshServerCache();
                 location.reload();
             } catch (error) {
                 console.error('🚨 DIAGNOSTIC: Error moving file', error);

--- a/templates/home.html
+++ b/templates/home.html
@@ -148,6 +148,9 @@
         {% endif %}
     </div>
 </div>
+<div id="loadingSpinner" class="text-center my-3" style="{% if not next_cursor %}display:none;{% endif %}">
+    <div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>
+</div>
 
 <!-- Folder selection modal for moving files -->
 <div class="modal fade" id="moveModal" tabindex="-1" role="dialog" aria-labelledby="moveModalLabel" aria-hidden="true">
@@ -167,6 +170,11 @@
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.0/socket.io.js"></script>
+<script>
+    window.nextCursor = {{ next_cursor if next_cursor is not none else 'null' }};
+    window.cacheTimestamp = {{ cache_timestamp or 0 }};
+    window.cachedEntries = {{ entries | tojson }};
+</script>
 <script src="{{ url_for('static', filename='streaming-upload.js') }}"></script>
 
 <script>


### PR DESCRIPTION
## Summary
- add in-memory per-user cache with async refresh and purge endpoints
- expose `/api/files/sync` for incremental file listings
- progressively render file table and refresh cache after mutations

## Testing
- `python -m py_compile app.py`
- `node --check static/streaming-upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68b71db9d6b4832fb68e569aa21320f8