### PR TITLE
Ensure file table updates after deletions

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -1146,6 +1146,9 @@ function setupFileActionEventHandlers(root = document) {
                 const responseData = await response.json();
                 if (responseData.status === 'success') {
                     this.closest('tr').remove();
+                    if (window.cachedEntries) {
+                        window.cachedEntries = window.cachedEntries.filter(e => e.id !== fileId);
+                    }
                     showStatus('File deleted successfully', 'success');
                     refreshServerCache();
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -260,6 +260,10 @@
                     const responseData = await response.json();
                     if (responseData.status === 'success') {
                         this.closest('tr').remove();
+                        if (window.cachedEntries) {
+                            window.cachedEntries = window.cachedEntries.filter(e => e.id !== fileId);
+                        }
+                        refreshServerCache();
                         showStatus('File deleted successfully', 'success');
                     } else {
                         showStatus(responseData.error || 'Failed to delete file', 'error');
@@ -431,6 +435,10 @@
                     const result = await resp.json();
                     if (result.status === 'success') {
                         selected.forEach(cb => cb.closest('tr').remove());
+                        if (window.cachedEntries) {
+                            window.cachedEntries = window.cachedEntries.filter(e => !fileIds.includes(e.id) && !folderIds.includes(e.id));
+                        }
+                        refreshServerCache();
                         showStatus('Selected items deleted', 'success');
                     } else {
                         showStatus(result.error || 'Failed to delete selected items', 'error');


### PR DESCRIPTION
## Summary
- Invalidate cached file listings after deleting files, folders, or bulk selections
- Remove deleted entries from `cachedEntries` and refresh cache on the client
- Keep file table in sync by updating streaming uploader script

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b746a661f8832f816d0303d4b3ed57