### PR TITLE
Encrypt uploaded streams before storing in Notion

### DIFF
--- a/tests/test_crypto_utils.py
+++ b/tests/test_crypto_utils.py
@@ -1,10 +1,17 @@
 import os
 import sys
 from pathlib import Path
+import importlib.util
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Load crypto_utils directly to avoid importing package with heavy dependencies
+utils_path = Path(__file__).resolve().parents[1] / 'uploader' / 'crypto_utils.py'
+spec = importlib.util.spec_from_file_location('crypto_utils', utils_path)
+crypto_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(crypto_utils)
 
-from uploader.crypto_utils import generate_key, encrypt_stream, decrypt_stream
+generate_key = crypto_utils.generate_key
+encrypt_stream = crypto_utils.encrypt_stream
+decrypt_stream = crypto_utils.decrypt_stream
 
 
 def test_round_trip_stream_encryption():

--- a/tests/test_stream_encryption.py
+++ b/tests/test_stream_encryption.py
@@ -1,0 +1,95 @@
+import os
+import sys
+from pathlib import Path
+import importlib.util
+import types
+
+repo_root = Path(__file__).resolve().parents[1]
+
+# Create a dummy 'uploader' package to satisfy relative imports without executing __init__
+# Stub package and dependencies to avoid heavy imports
+uploader_pkg = types.ModuleType('uploader')
+uploader_pkg.__path__ = [str(repo_root / 'uploader')]
+sys.modules['uploader'] = uploader_pkg
+
+dummy_notion = types.ModuleType('uploader.notion_uploader')
+class NotionFileUploader:
+    pass
+dummy_notion.NotionFileUploader = NotionFileUploader
+sys.modules['uploader.notion_uploader'] = dummy_notion
+
+dummy_s3 = types.ModuleType('uploader.s3_downloader')
+def download_file_from_url(url, path):
+    raise NotImplementedError
+dummy_s3.download_file_from_url = download_file_from_url
+sys.modules['uploader.s3_downloader'] = dummy_s3
+
+su_path = repo_root / 'uploader' / 'streaming_uploader.py'
+spec = importlib.util.spec_from_file_location('uploader.streaming_uploader', su_path)
+su = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(su)
+NotionStreamingUploader = su.NotionStreamingUploader
+
+cu_path = repo_root / 'uploader' / 'crypto_utils.py'
+cu_spec = importlib.util.spec_from_file_location('uploader.crypto_utils', cu_path)
+cu = importlib.util.module_from_spec(cu_spec)
+cu_spec.loader.exec_module(cu)
+encrypt_stream = cu.encrypt_stream
+decrypt_stream = cu.decrypt_stream
+
+
+class DummyNotionUploader:
+    def __init__(self):
+        self.uploaded_bytes = None
+        self.encryption_meta = None
+
+    def upload_single_file_stream(self, file_stream, filename, database_id, content_type,
+                                   file_size, original_filename, encryption_meta=None):
+        chunks = list(file_stream)
+        if encryption_meta:
+            key = encryption_meta['key']
+            iv = encryption_meta['iv']
+            chunks = list(encrypt_stream(key, iv, iter(chunks)))
+        self.uploaded_bytes = b"".join(chunks)
+        self.encryption_meta = encryption_meta
+        return {'file_upload_id': '1', 'result': {}}
+
+
+def test_single_part_stream_encrypted():
+    dummy = DummyNotionUploader()
+    uploader = NotionStreamingUploader(api_token='token', notion_uploader=dummy)
+    data = b'hello world' * 1000
+    session = uploader.create_upload_session('test.txt', len(data), 'db')
+    uploader._process_single_part_stream(session, iter([data]), db_integration=False)
+
+    encrypted = dummy.uploaded_bytes
+    assert encrypted != data
+    enc = session['encryption_meta']
+    decrypted = b"".join(decrypt_stream(enc['key'], enc['iv'], [encrypted]))
+    assert decrypted == data
+
+
+def test_multipart_stream_encrypted(monkeypatch):
+    capture = {}
+
+    class DummyParallelProcessor:
+        def __init__(self, max_workers=10, notion_uploader=None, upload_session=None, socketio=None):
+            capture['data'] = b''
+
+        def process_stream(self, stream_generator, resume_from=0):
+            for chunk in stream_generator:
+                capture['data'] += chunk
+            return {'file_upload_id': 'id', 'status': 'completed', 'result': {}}
+
+    monkeypatch.setattr(su, 'ParallelChunkProcessor', DummyParallelProcessor)
+
+    uploader = NotionStreamingUploader(api_token='token', notion_uploader=None)
+    data = b'A' * (1024 * 1024)
+    session = uploader.create_upload_session('big.bin', len(data), 'db')
+    uploader._process_multipart_stream(session, iter([data]), db_integration=False)
+
+    encrypted = capture['data']
+    assert encrypted != data
+    enc = session['encryption_meta']
+    decrypted = b"".join(decrypt_stream(enc['key'], enc['iv'], [encrypted]))
+    assert decrypted == data


### PR DESCRIPTION
## Summary
- use session AES key/IV when uploading file parts and manifests
- stream-encrypt multipart uploads while maintaining plaintext hashes
- add tests verifying encryption for single and multipart streams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8039903e8832f9c51ac71f16f7e2d