### PR TITLE
Handle missing rich text in hash routes

### DIFF
--- a/tests/test_property_utils.py
+++ b/tests/test_property_utils.py
@@ -1,0 +1,16 @@
+import pytest
+from app import safe_get_property_text
+
+
+def test_safe_get_property_text_empty_list():
+    prop = {'rich_text': []}
+    assert safe_get_property_text(prop) == ''
+
+
+def test_safe_get_property_text_missing_key():
+    assert safe_get_property_text({}) == ''
+
+
+def test_safe_get_property_text_title():
+    prop = {'title': [{'text': {'content': 'hello'}}]}
+    assert safe_get_property_text(prop, key='title') == 'hello'


### PR DESCRIPTION
## Summary
- avoid IndexError in `/d/<hash>` and `/v/<hash>` routes when Notion `rich_text` fields are empty
- add helper `safe_get_property_text` to guard property access
- test helper for empty or missing `rich_text` values

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b82722a96c832fbff01ec72fc16463