### PR TITLE
Handle AES-GCM authentication tag during download

### DIFF
--- a/uploader/s3_downloader.py
+++ b/uploader/s3_downloader.py
@@ -291,6 +291,7 @@ def stream_file_from_url(
     *,
     key: bytes | None = None,
     iv: bytes | None = None,
+    tag: bytes | None = None,
 ):
     """Stream an object using its full pre-signed URL.
 
@@ -300,15 +301,15 @@ def stream_file_from_url(
         Pre-signed S3 URL to stream from.
     chunk_size:
         Size of chunks to yield.
-    key, iv:
+    key, iv, tag:
         Optional AES parameters. When provided, the response stream is
         transparently decrypted using :func:`decrypt_stream` while preserving
         chunked iteration.
     """
 
     stream = _stream_presigned_url(url, chunk_size=chunk_size)
-    if key and iv:
-        return decrypt_stream(key, iv, stream)
+    if key and iv and tag:
+        return decrypt_stream(key, iv, tag, stream)
     return stream
 
 
@@ -320,15 +321,17 @@ def stream_file_range_from_url(
     *,
     key: bytes | None = None,
     iv: bytes | None = None,
+    tag: bytes | None = None,
 ):
     """Stream a specific byte range from a pre-signed S3 URL.
 
-    The returned iterator yields decrypted chunks when ``key`` and ``iv`` are
-    supplied, allowing callers to lazily decrypt large files while streaming.
+    The returned iterator yields decrypted chunks when ``key``, ``iv``, and
+    ``tag`` are supplied, allowing callers to lazily decrypt large files while
+    streaming.
     """
 
     headers = {"Range": f"bytes={start}-{end}"}
     stream = _stream_presigned_url(url, headers=headers, chunk_size=chunk_size)
-    if key and iv:
-        return decrypt_stream(key, iv, stream)
+    if key and iv and tag:
+        return decrypt_stream(key, iv, tag, stream)
     return stream


### PR DESCRIPTION
## Summary
- propagate nonce/tag metadata from Notion to allow AES-GCM decryption
- include authentication tag in Notion DB records
- extend S3 downloader to supply tag when decrypting streams

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b828cb6410832fadf9f8b93e076dfd