### PR TITLE
Fix encrypted multipart downloads

### DIFF
--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -21,8 +21,18 @@ from flask_socketio import SocketIO
 from .notion_uploader import NotionFileUploader
 from .parallel_processor import ParallelChunkProcessor, generate_salt, calculate_salted_hash
 from .s3_downloader import download_file_from_url
-from .crypto_utils import generate_file_key, encrypt_stream, wrap_file_key
+import importlib.util
+from pathlib import Path
 import gc
+
+_crypto_spec = importlib.util.spec_from_file_location(
+    "uploader.crypto_utils", Path(__file__).with_name("crypto_utils.py")
+)
+_crypto = importlib.util.module_from_spec(_crypto_spec)
+_crypto_spec.loader.exec_module(_crypto)
+generate_file_key = _crypto.generate_file_key
+encrypt_stream = _crypto.encrypt_stream
+wrap_file_key = _crypto.wrap_file_key
 
 
 def _fetch_text(url: str) -> str:


### PR DESCRIPTION
## Summary
- decrypt JSON manifests using AES-GCM when downloading multipart files
- pass encryption parameters through download routes
- handle decryption inside NotionFileUploader and clean up crypto imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b937515538832f91b40a078712db95