### PR TITLE
Fix decryption for multi-part downloads without link key

### DIFF
--- a/tests/test_link_sharing.py
+++ b/tests/test_link_sharing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import types
 import pytest
 import sys
+import urllib.parse
 
 repo_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(repo_root))
@@ -127,7 +128,8 @@ def test_extract_requires_link_key():
         with pytest.raises(PermissionError):
             extract_encryption_params(props)
     lk_b64 = base64.b64encode(lk).decode()
-    with app.test_request_context(f'/download?lk={lk_b64}'):
+    lk_q = urllib.parse.quote(lk_b64)
+    with app.test_request_context(f'/download?lk={lk_q}'):
         key, n, t = extract_encryption_params(props)
         decrypted = b''.join(decrypt_stream(key, n, t, [ciphertext]))
         assert decrypted == plaintext

--- a/tests/test_multipart_decrypt.py
+++ b/tests/test_multipart_decrypt.py
@@ -1,0 +1,151 @@
+import os
+import base64
+import types
+from pathlib import Path
+import importlib.util
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+for name in [
+    'uploader',
+    'uploader.notion_uploader',
+    'uploader.s3_downloader',
+    'uploader.crypto_utils',
+    's3_downloader',
+    'crypto_utils',
+]:
+    sys.modules.pop(name, None)
+
+uploader_pkg = types.ModuleType('uploader')
+uploader_pkg.__path__ = [str(repo_root / 'uploader')]
+sys.modules['uploader'] = uploader_pkg
+
+nu_spec = importlib.util.spec_from_file_location('uploader.notion_uploader', repo_root / 'uploader' / 'notion_uploader.py')
+nu = importlib.util.module_from_spec(nu_spec)
+nu_spec.loader.exec_module(nu)
+sys.modules['uploader.notion_uploader'] = nu
+sys.modules['uploader'].notion_uploader = nu
+NotionFileUploader = nu.NotionFileUploader
+
+cu_spec = importlib.util.spec_from_file_location('uploader.crypto_utils', repo_root / 'uploader' / 'crypto_utils.py')
+cu = importlib.util.module_from_spec(cu_spec)
+cu_spec.loader.exec_module(cu)
+sys.modules['uploader.crypto_utils'] = cu
+sys.modules['uploader'].crypto_utils = cu
+encrypt_stream = cu.encrypt_stream
+
+
+def test_stream_multi_part_file_decrypts_without_link_key(monkeypatch):
+    file_key = os.urandom(32)
+    data = b'hello world' * 100
+    nonce = os.urandom(12)
+    enc_iter, tag = encrypt_stream(file_key, nonce, [data])
+    ciphertext = b"".join(enc_iter)
+
+    manifest = {
+        "parts": [
+            {
+                "part_number": 1,
+                "filename": "part1",
+                "file_hash": "hash1",
+                "size": len(ciphertext),
+                "nonce_b64": base64.b64encode(nonce).decode(),
+                "tag_b64": base64.b64encode(tag).decode(),
+            }
+        ]
+    }
+
+    # Patch _fetch_json to return our manifest
+    monkeypatch.setattr(nu, '_fetch_json', lambda url, key=None, nonce=None, tag=None: manifest)
+
+    uploader = NotionFileUploader(api_token='token')
+
+    # Stub out methods used by stream_multi_part_file
+    def fake_get_user_by_id(self, page_id):
+        return {
+            'properties': {
+                'file_data': {'files': [{'file': {'url': 'unused'}}]},
+                'nonce': {'rich_text': [{'text': {'content': 'none'}}]},
+                'tag': {'rich_text': [{'text': {'content': 'none'}}]},
+            }
+        }
+
+    def fake_get_file_by_hash(self, file_hash):
+        return {
+            'properties': {
+                'File Page ID': {'rich_text': [{'text': {'content': 'part1'}}]}
+            }
+        }
+
+    def fake_stream_file_from_notion(self, page_id, filename, download_url=None, chunk_size=None):
+        return [ciphertext]
+
+    def fake_stream_range(self, page_id, filename, start, end, download_url=None, chunk_size=None):
+        return [ciphertext[start:end+1]]
+
+    uploader.get_user_by_id = types.MethodType(fake_get_user_by_id, uploader)
+    uploader.get_file_by_salted_sha512_hash = types.MethodType(fake_get_file_by_hash, uploader)
+    uploader.stream_file_from_notion = types.MethodType(fake_stream_file_from_notion, uploader)
+    uploader.stream_file_from_notion_range = types.MethodType(fake_stream_range, uploader)
+
+    output = b"".join(uploader.stream_multi_part_file('manifest', file_key=file_key))
+    assert output == data
+
+
+def test_stream_multi_part_file_partial_range(monkeypatch):
+    file_key = os.urandom(32)
+    data = b'hello world' * 100
+    nonce = os.urandom(12)
+    enc_iter, tag = encrypt_stream(file_key, nonce, [data])
+    ciphertext = b"".join(enc_iter)
+
+    manifest = {
+        "parts": [
+            {
+                "part_number": 1,
+                "filename": "part1",
+                "file_hash": "hash1",
+                "size": len(ciphertext),
+                "nonce_b64": base64.b64encode(nonce).decode(),
+                "tag_b64": base64.b64encode(tag).decode(),
+            }
+        ]
+    }
+
+    monkeypatch.setattr(nu, '_fetch_json', lambda url, key=None, nonce=None, tag=None: manifest)
+
+    uploader = NotionFileUploader(api_token='token')
+
+    def fake_get_user_by_id(self, page_id):
+        return {
+            'properties': {
+                'file_data': {'files': [{'file': {'url': 'unused'}}]},
+                'nonce': {'rich_text': [{'text': {'content': 'none'}}]},
+                'tag': {'rich_text': [{'text': {'content': 'none'}}]},
+            }
+        }
+
+    def fake_get_file_by_hash(self, file_hash):
+        return {
+            'properties': {
+                'File Page ID': {'rich_text': [{'text': {'content': 'part1'}}]}
+            }
+        }
+
+    def fake_stream_file_from_notion(self, page_id, filename, download_url=None, chunk_size=None):
+        return [ciphertext]
+
+    def fake_stream_range(*args, **kwargs):
+        raise AssertionError('range streaming not expected for encrypted parts')
+
+    uploader.get_user_by_id = types.MethodType(fake_get_user_by_id, uploader)
+    uploader.get_file_by_salted_sha512_hash = types.MethodType(fake_get_file_by_hash, uploader)
+    uploader.stream_file_from_notion = types.MethodType(fake_stream_file_from_notion, uploader)
+    uploader.stream_file_from_notion_range = types.MethodType(fake_stream_range, uploader)
+
+    start = 10
+    end = 150
+    output = b"".join(
+        uploader.stream_multi_part_file('manifest', start=start, end=end, file_key=file_key)
+    )
+    assert output == data[start:end + 1]

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -326,7 +326,13 @@ class NotionFileUploader:
 
             def worker() -> None:
                 try:
-                    if part_info['start'] > 0 or part_info['end'] < part_info['size'] - 1:
+                    is_encrypted = part_info.get('nonce_b64') and part_info.get('tag_b64')
+
+                    if is_encrypted:
+                        iterator = self.stream_file_from_notion(
+                            part_info['page_id'], part_info['filename']
+                        )
+                    elif part_info['start'] > 0 or part_info['end'] < part_info['size'] - 1:
                         iterator = self.stream_file_from_notion_range(
                             part_info['page_id'],
                             part_info['filename'],
@@ -338,11 +344,35 @@ class NotionFileUploader:
                             part_info['page_id'], part_info['filename']
                         )
 
-                    if link_key and part_info.get('wrapped_fk_b64') and part_info.get('nonce_b64') and part_info.get('tag_b64'):
-                        part_key = unwrap_file_key(base64.b64decode(part_info['wrapped_fk_b64']), link_key)
-                        nonce = base64.b64decode(part_info['nonce_b64'])
-                        tag = base64.b64decode(part_info['tag_b64'])
-                        iterator = decrypt_stream(part_key, nonce, tag, iterator)
+                    if is_encrypted:
+                        part_key = None
+                        if link_key and part_info.get('wrapped_fk_b64'):
+                            part_key = unwrap_file_key(
+                                base64.b64decode(part_info['wrapped_fk_b64']), link_key
+                            )
+                        elif file_key:
+                            part_key = file_key
+                        if part_key:
+                            nonce = base64.b64decode(part_info['nonce_b64'])
+                            tag = base64.b64decode(part_info['tag_b64'])
+                            iterator = decrypt_stream(part_key, nonce, tag, iterator)
+
+                    if part_info['start'] > 0 or part_info['end'] < part_info['size'] - 1:
+                        def slice_stream(it, start, end):
+                            pos = 0
+                            for chunk in it:
+                                next_pos = pos + len(chunk)
+                                if next_pos <= start:
+                                    pos = next_pos
+                                    continue
+                                if pos > end:
+                                    pos = next_pos
+                                    continue
+                                s = max(0, start - pos)
+                                e = min(len(chunk), end - pos + 1)
+                                yield chunk[s:e]
+                                pos = next_pos
+                        iterator = slice_stream(iterator, part_info['start'], part_info['end'])
 
                     for chunk in iterator:
                         q.put(chunk)


### PR DESCRIPTION
## Summary
- allow `stream_multi_part_file` to decrypt parts using the file key when no link key is present
- handle byte-range requests for encrypted parts by downloading the full ciphertext and slicing after decryption
- add regression tests for full and partial multi-part decryption
- ensure test link keys are URL encoded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93f8c637c832facbb13e1e76bcce2