### PR TITLE
Support link key mapping in folder downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,6 @@ import uuid
 import random
 import string
 import json
-import urllib.parse
 from flask_socketio import emit
 from collections import defaultdict
 import gc
@@ -689,7 +688,7 @@ def download_folder():
         default_link_key: bytes | None = None
         if lk_map_param:
             try:
-                decoded = json.loads(urllib.parse.unquote(lk_map_param))
+                decoded = json.loads(lk_map_param)
                 for fid, b64 in decoded.items():
                     try:
                         lk_map[fid] = base64.b64decode(b64)

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -1373,7 +1373,7 @@ function setupFolderActionEventHandlers(root = document) {
             const folder = url.searchParams.get('folder') || '/';
             const lkMap = await collectLinkKeysForFolder(folder);
             if (Object.keys(lkMap).length > 0) {
-                url.searchParams.set('lk_map', encodeURIComponent(JSON.stringify(lkMap)));
+                url.searchParams.set('lk_map', JSON.stringify(lkMap));
             }
             window.location.href = url.pathname + url.search;
         });

--- a/tests/test_download_folder_lk_map.py
+++ b/tests/test_download_folder_lk_map.py
@@ -4,7 +4,6 @@ import hashlib
 import importlib.util
 from pathlib import Path
 import types
-import urllib.parse
 import io
 import zipfile
 import json
@@ -118,9 +117,9 @@ def test_download_folder_multiple_link_keys(monkeypatch):
     monkeypatch.setattr(app_mod, 'current_user', types.SimpleNamespace(id='user'))
 
     lk_map = {'file1': base64.b64encode(lk1).decode(), 'file2': base64.b64encode(lk2).decode()}
-    lk_map_enc = urllib.parse.quote(json.dumps(lk_map))
+    lk_map_json = json.dumps(lk_map)
 
-    with app_mod.app.test_request_context(f'/download_folder?folder=/&lk_map={lk_map_enc}'):
+    with app_mod.app.test_request_context('/download_folder', query_string={'folder': '/', 'lk_map': lk_map_json}):
         resp = app_mod.download_folder.__wrapped__()
         data = b''.join(resp.response)
     zf = zipfile.ZipFile(io.BytesIO(data))


### PR DESCRIPTION
## Summary
- Capture link keys from the browser and send them as a `lk_map` parameter when downloading folders.
- Parse and apply `lk_map` on the server to decrypt files during folder downloads.
- Add unit tests verifying successful downloads with `lk_map` and 403 errors when keys are missing.

## Testing
- `pytest tests/test_download_folder_lk_map.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba85cebf7c832f821dd4a0a481b72d