### PR TITLE
Fix dropdown menu hidden behind table

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -247,8 +247,17 @@ button:hover,
     margin: 20px 0;
     background-color: #1e1e1e;
     border-radius: 5px;
-    overflow: hidden;
+    /* Allow elements like dropdown menus to extend outside the table.
+       The previous overflow:hidden clipped the action menu making it
+       appear behind other elements. */
+    overflow: visible;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+/* Ensure responsive table containers don't hide dropdown menus */
+.table-responsive {
+    overflow-x: auto;
+    overflow-y: visible;
 }
 
 .table th,


### PR DESCRIPTION
## Summary
- prevent table and responsive wrapper from clipping dropdown menus
- allow file action menu to display outside table boundaries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb10625650832fa5300a19598f86dc