### PR TITLE
Preserve scroll position when refreshing file list

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -226,15 +226,15 @@ function restoreDropdownState() {
 window.fileTableScrollTop = window.fileTableScrollTop || 0;
 
 function captureFileTableScroll() {
-    const container = document.getElementById('files-container');
-    window.fileTableScrollTop = container ? container.scrollTop : window.scrollY || 0;
+    // Always capture the current page scroll position. Using a container's
+    // scrollTop caused the window scroll position to be lost when the file
+    // list was re-rendered, forcing the page back to the top after a refresh.
+    window.fileTableScrollTop = window.scrollY || 0;
 }
 
 function restoreFileTableScroll() {
-    const container = document.getElementById('files-container');
-    if (container) {
-        container.scrollTop = window.fileTableScrollTop || 0;
-    }
+    // Restore the previously captured page scroll position so the user's place
+    // in the file list is preserved after the table is refreshed.
     window.scrollTo(0, window.fileTableScrollTop || 0);
 }
 


### PR DESCRIPTION
## Summary
- Maintain page scroll position by tracking `window.scrollY` rather than container scroll values
- Restore captured scroll to keep user's position after file list refresh

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2b337834832fa39ab59d7cad0edb