### PR TITLE
Preserve file table scroll position on refresh

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -223,19 +223,33 @@ function restoreDropdownState() {
 }
 
 // Preserve file table scroll position across refreshes
+// Preserve both the overall page scroll position and the scroll position
+// within the files table container so that refreshes don't reset either.
 window.fileTableScrollTop = window.fileTableScrollTop || 0;
+window.fileTableInnerScrollTop = window.fileTableInnerScrollTop || 0;
 
 function captureFileTableScroll() {
-    // Always capture the current page scroll position. Using a container's
-    // scrollTop caused the window scroll position to be lost when the file
-    // list was re-rendered, forcing the page back to the top after a refresh.
+    // Capture the page's current scroll position
     window.fileTableScrollTop = window.scrollY || 0;
+
+    // Capture the scroll position of the table's responsive wrapper
+    const tableWrapper = document.querySelector('#files-container .table-responsive') ||
+                         document.getElementById('files-container');
+    if (tableWrapper) {
+        window.fileTableInnerScrollTop = tableWrapper.scrollTop || 0;
+    }
 }
 
 function restoreFileTableScroll() {
-    // Restore the previously captured page scroll position so the user's place
-    // in the file list is preserved after the table is refreshed.
+    // Restore the page scroll position first
     window.scrollTo(0, window.fileTableScrollTop || 0);
+
+    // Then restore the inner table wrapper scroll position
+    const tableWrapper = document.querySelector('#files-container .table-responsive') ||
+                         document.getElementById('files-container');
+    if (tableWrapper) {
+        tableWrapper.scrollTop = window.fileTableInnerScrollTop || 0;
+    }
 }
 
 function formatBytes(bytes) {


### PR DESCRIPTION
## Summary
- Preserve files table scroll position by saving and restoring its `scrollTop` alongside page scroll.
- Fix restoration to target the table's responsive wrapper element.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb5ddc3168832f8d9bdf116f01c8db