### PR TITLE
Overlay file action dropdown menus

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -256,7 +256,13 @@ button:hover,
 
 /* Ensure responsive table containers don't hide dropdown menus */
 .table-responsive {
-    overflow-x: auto;
+    overflow: visible;
+}
+
+/* Ensure dropdown menus from file actions appear above other content */
+.table .dropdown-menu {
+    position: absolute;
+    z-index: 2000;
 }
 
 .table th,

--- a/templates/home.html
+++ b/templates/home.html
@@ -49,8 +49,7 @@
     </div>
     <div id="files-container">
         <!-- Files will be loaded here via JavaScript or directly from Flask context -->
-        <div class="table-responsive">
-            <table class="table">
+        <table class="table">
                 <thead>
                     <tr>
                         <th></th>
@@ -139,7 +138,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-        </div>
         {% if not entries and next_cursor is none %}
         <div class="alert alert-info text-center">
             <p><i class="fas fa-info-circle mr-2"></i>No files found. Upload your first file above.</p>


### PR DESCRIPTION
## Summary
- Drop the extra `.table-responsive` wrapper so file listings use full page width
- Ensure file action dropdown menus overlay other content with higher z-index

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb61a85600832faaeb66377bd180db