### PR TITLE
Overlay file action dropdown menus

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -232,9 +232,8 @@ function captureFileTableScroll() {
     // Capture the page's current scroll position
     window.fileTableScrollTop = window.scrollY || 0;
 
-    // Capture the scroll position of the table's responsive wrapper
-    const tableWrapper = document.querySelector('#files-container .table-responsive') ||
-                         document.getElementById('files-container');
+    // Capture the scroll position of the files container
+    const tableWrapper = document.getElementById('files-container');
     if (tableWrapper) {
         window.fileTableInnerScrollTop = tableWrapper.scrollTop || 0;
     }
@@ -244,9 +243,8 @@ function restoreFileTableScroll() {
     // Restore the page scroll position first
     window.scrollTo(0, window.fileTableScrollTop || 0);
 
-    // Then restore the inner table wrapper scroll position
-    const tableWrapper = document.querySelector('#files-container .table-responsive') ||
-                         document.getElementById('files-container');
+    // Then restore the files container scroll position
+    const tableWrapper = document.getElementById('files-container');
     if (tableWrapper) {
         tableWrapper.scrollTop = window.fileTableInnerScrollTop || 0;
     }
@@ -966,20 +964,19 @@ function renderEntries(entries) {
     }
 
     let tableHTML = `
-        <div class="table-responsive">
-            <table class="table" id="fileTable">
-                <thead>
-                    <tr>
-                        <th></th>
-                        <th><i class="fas fa-file mr-1"></i> Filename</th>
-                        <th><i class="fas fa-weight mr-1"></i> Size</th>
-                        <th>Folder</th>
-                        <th><i class="fas fa-link mr-1"></i> Public Link</th>
-                        <th><i class="fas fa-lock-open mr-1"></i> Public Access</th>
-                        <th><i class="fas fa-cogs mr-1"></i> Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
+        <table class="table" id="fileTable">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th><i class="fas fa-file mr-1"></i> Filename</th>
+                    <th><i class="fas fa-weight mr-1"></i> Size</th>
+                    <th>Folder</th>
+                    <th><i class="fas fa-link mr-1"></i> Public Link</th>
+                    <th><i class="fas fa-lock-open mr-1"></i> Public Access</th>
+                    <th><i class="fas fa-cogs mr-1"></i> Actions</th>
+                </tr>
+            </thead>
+            <tbody>
     `;
 
     entries.forEach(entry => {
@@ -1056,7 +1053,7 @@ function renderEntries(entries) {
         }
     });
 
-    tableHTML += `</tbody></table></div>`;
+    tableHTML += `</tbody></table>`;
     filesContainer.innerHTML = tableHTML;
 
     setupFileActionEventHandlers();

--- a/static/style.css
+++ b/static/style.css
@@ -256,7 +256,13 @@ button:hover,
 
 /* Ensure responsive table containers don't hide dropdown menus */
 .table-responsive {
-    overflow-x: auto;
+    overflow: visible;
+}
+
+/* Ensure dropdown menus from file actions appear above other content */
+.table .dropdown-menu {
+    position: absolute;
+    z-index: 2000;
 }
 
 .table th,

--- a/static/upload.js
+++ b/static/upload.js
@@ -190,7 +190,6 @@ async function loadFiles() {
 
         // Generate the table HTML to match the initial server-rendered table
         let tableHTML = `
-            <div class="table-responsive">
                 <table class="table" id="fileTable">
                     <thead>
                         <tr>
@@ -253,7 +252,6 @@ async function loadFiles() {
         tableHTML += `
                     </tbody>
                 </table>
-            </div>
         `;
 
         // Update the container

--- a/templates/home.html
+++ b/templates/home.html
@@ -49,8 +49,7 @@
     </div>
     <div id="files-container">
         <!-- Files will be loaded here via JavaScript or directly from Flask context -->
-        <div class="table-responsive">
-            <table class="table">
+        <table class="table">
                 <thead>
                     <tr>
                         <th></th>
@@ -139,7 +138,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-        </div>
         {% if not entries and next_cursor is none %}
         <div class="alert alert-info text-center">
             <p><i class="fas fa-info-circle mr-2"></i>No files found. Upload your first file above.</p>
@@ -716,12 +714,6 @@
 
 <style>
     /* Additional local styles */
-    .table-responsive {
-        overflow-x: auto;
-        margin-bottom: 20px;
-        border-radius: 5px;
-    }
-
     .action-buttons {
         white-space: nowrap;
     }


### PR DESCRIPTION
## Summary
- Drop the extra `.table-responsive` wrapper so file listings use full page width
- Ensure file action dropdown menus overlay other content with higher z-index
- Keep refreshed file lists from reintroducing the scroll wrapper by targeting the files container directly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb61a85600832faaeb66377bd180db