### PR TITLE
Ensure consistent file table spacing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -359,6 +359,17 @@ button:hover,
     }
 }
 
+/* Ensure consistent spacing for file table columns */
+#fileTable {
+    width: 100%;
+    table-layout: fixed;
+}
+
+#fileTable th,
+#fileTable td {
+    padding: 12px;
+}
+
 .filesize-cell {
     white-space: nowrap;
     text-align: right;

--- a/templates/home.html
+++ b/templates/home.html
@@ -49,7 +49,7 @@
     </div>
     <div id="files-container">
         <!-- Files will be loaded here via JavaScript or directly from Flask context -->
-        <table class="table">
+        <table class="table" id="fileTable">
                 <thead>
                     <tr>
                         <th></th>


### PR DESCRIPTION
## Summary
- add a dedicated `id` to the file table markup
- style the file table to keep column spacing uniform after refresh

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb67fcf690832f954ec26cc40bf71e