### PR TITLE
Make layout full width and rebalance file table columns

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -34,10 +34,8 @@ h2 {
     padding: 30px;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-    width: 100%;
-    max-width: 1200px;
     box-sizing: border-box;
-    margin: 20px auto;
+    margin: 20px;
 }
 
 .form-group {
@@ -375,12 +373,12 @@ button:hover,
 }
 
 #fileTable .select-column {
-    width: 5%;
+    width: 3%;
     min-width: 30px;
 }
 
 #fileTable .filename-column {
-    width: 35%;
+    width: 40%;
 }
 
 #fileTable .size-column {
@@ -414,7 +412,7 @@ button:hover,
 
 #fileTable th:last-child,
 #fileTable td:last-child {
-    width: 10%;
+    width: 7%;
 }
 
 .filesize-cell {


### PR DESCRIPTION
## Summary
- Expand the main content container to span the full device width
- Rebalance file table column widths to avoid overlap and prioritize filename display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc0f3d9438832f9efe805e059f7eaa