### PR TITLE
Make layout full width and rebalance file table columns

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -34,10 +34,8 @@ h2 {
     padding: 30px;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-    width: 100%;
-    max-width: 1200px;
     box-sizing: border-box;
-    margin: 20px auto;
+    margin: 20px;
 }
 
 .form-group {
@@ -360,7 +358,7 @@ button:hover,
 
 /* Ensure consistent spacing for file table columns */
 #files-container {
-    overflow-x: auto;
+    overflow-x: hidden;
 }
 
 #fileTable {
@@ -372,31 +370,32 @@ button:hover,
 #fileTable th,
 #fileTable td {
     padding: 12px;
+    box-sizing: border-box;
 }
 
 #fileTable .select-column {
-    width: 5%;
+    width: 3%;
     min-width: 30px;
 }
 
 #fileTable .filename-column {
-    width: 35%;
+    width: auto;
 }
 
 #fileTable .size-column {
-    width: 10%;
+    width: 8%;
 }
 
 #fileTable .folder-column {
-    width: 15%;
+    width: 12%;
 }
 
 #fileTable .public-link-column {
-    width: 20%;
+    width: 18%;
 }
 
 #fileTable .public-access-column {
-    width: 5%;
+    width: 4%;
 }
 
 /* Allow long text to wrap inside table cells */
@@ -405,6 +404,7 @@ button:hover,
 #fileTable .public-link-column {
     white-space: normal;
     overflow-wrap: anywhere;
+    word-break: normal;
 }
 
 #fileTable .public-link-column .public-link {
@@ -414,7 +414,7 @@ button:hover,
 
 #fileTable th:last-child,
 #fileTable td:last-child {
-    width: 10%;
+    width: 7%;
 }
 
 .filesize-cell {


### PR DESCRIPTION
## Summary
- Expand the main content container to span the full device width
- Rebalance file table column widths to avoid overlap and prioritize filename display
- Prevent horizontal scrolling and ensure filenames use the full column width before wrapping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f3d9438832f9efe805e059f7eaa