### PR TITLE
Simplify file table scroll handling

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -222,32 +222,17 @@ function restoreDropdownState() {
     }
 }
 
-// Preserve file table scroll position across refreshes
-// Preserve both the overall page scroll position and the scroll position
-// within the files table container so that refreshes don't reset either.
+// Preserve file table scroll position across refreshes using only the page scroll
 window.fileTableScrollTop = window.fileTableScrollTop || 0;
-window.fileTableInnerScrollTop = window.fileTableInnerScrollTop || 0;
 
 function captureFileTableScroll() {
     // Capture the page's current scroll position
     window.fileTableScrollTop = window.scrollY || 0;
-
-    // Capture the scroll position of the files container
-    const tableWrapper = document.getElementById('files-container');
-    if (tableWrapper) {
-        window.fileTableInnerScrollTop = tableWrapper.scrollTop || 0;
-    }
 }
 
 function restoreFileTableScroll() {
-    // Restore the page scroll position first
+    // Restore the page scroll position
     window.scrollTo(0, window.fileTableScrollTop || 0);
-
-    // Then restore the files container scroll position
-    const tableWrapper = document.getElementById('files-container');
-    if (tableWrapper) {
-        tableWrapper.scrollTop = window.fileTableInnerScrollTop || 0;
-    }
 }
 
 function formatBytes(bytes) {

--- a/static/style.css
+++ b/static/style.css
@@ -358,8 +358,7 @@ button:hover,
 
 /* Ensure consistent spacing for file table columns */
 #files-container {
-    /* Allow the table to shrink without forcing hidden overflow */
-    overflow-x: auto;
+    /* No overflow or height constraints so the table scrolls with the page */
 }
 
 #fileTable {


### PR DESCRIPTION
## Summary
- remove inner table scroll tracking and rely solely on window scroll position
- allow file table container to scroll with page by removing overflow constraints

## Testing
- `pytest`
- `node - <<'NODE'\nconst fs=require('fs');\nconst css=fs.readFileSync('static/style.css','utf8');\nconst ruleClean=(css.match(/#files-container\\s*{[^}]*}/) || [''])[0].replace(/\\/\\*[^]*?\\*\\//g,'');\nconsole.log(ruleClean.trim());\nconsole.log('overflow property present?', /overflow/i.test(ruleClean));\nconsole.log('height property present?', /height/i.test(ruleClean));\nNODE`
- `node - <<'NODE'\nlet window = {scrollY: 200, scrollTo: (x, y) => {window.scrollY = y;}};\nlet fileTableScrollTop = 0;\nfunction captureFileTableScroll(){\n  window.fileTableScrollTop = window.scrollY || 0;\n}\nfunction restoreFileTableScroll(){\n  window.scrollTo(0, window.fileTableScrollTop || 0);\n}\ncaptureFileTableScroll();\nwindow.scrollY = 0;\nrestoreFileTableScroll();\nconsole.log('scrollY after restore:', window.scrollY);\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68bc1c6c0900832fb85bece335095b53