### PR TITLE
Prevent horizontal scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,7 @@
+html {
+    overflow-x: hidden;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: #121212;
@@ -7,6 +11,7 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 .navbar {


### PR DESCRIPTION
## Summary
- prevent horizontal page scrolling by hiding overflow on html and body

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc1e877b4c832fb9060ba5dfc7979a