### PR TITLE
Fix main content layout centering

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -40,7 +40,9 @@ h2 {
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
-    margin: 20px;
+    margin: 20px auto;
+    width: 100%;
+    max-width: calc(100% - 40px);
 }
 
 .form-group {


### PR DESCRIPTION
## Summary
- center the main content container to eliminate rightward shift
- ensure file table spans full width within centered layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d2b83dc832fa74bb6493a63086c