### PR TITLE
Add asynchronous account deletion

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -145,6 +145,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="#" onclick="if(confirm('Are you sure you want to delete your account? This cannot be undone.')) { fetch('/delete_account', {method: 'POST'}).then(() => { window.location = '/login'; }); } return false;">
+                            <i class="fas fa-user-times mr-1"></i> Delete Account
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/logout">
                             <i class="fas fa-sign-out-alt mr-1"></i> Logout
                         </a>


### PR DESCRIPTION
## Summary
- Allow users to trigger deletion of their account without waiting
- Remove all user files and archive account in a background thread
- Expose delete account option in navigation bar

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be97816dd4832fae0a4ee36fa784fb