### PR TITLE
Add link security settings and password-protected downloads

### DIFF
--- a/templates/password_prompt.html
+++ b/templates/password_prompt.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-5">
+    <h2>Enter Password</h2>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="POST">
+        <div class="form-group">
+            <input type="password" name="password" class="form-control" placeholder="Password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/update_link_settings` endpoint for public status, password, and expiry updates
- expose `password_protected` and `expires_at` in file listing and search APIs
- require password and expiry checks when downloading by hash with a new password prompt page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfd0845f94832fb35fe684c9c3929b