### PR TITLE
Invalidate index cache after security updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1679,7 +1679,12 @@ def update_link_settings():
 
         # Update public status and security settings
         uploader.update_file_public_status(file_id, is_public, salted_sha512_hash)
-        uploader.update_file_security_settings(file_id, password_hash=password_hash, expires_at=expires_at)
+        uploader.update_file_security_settings(
+            file_id,
+            password_hash=password_hash,
+            expires_at=expires_at,
+            salted_sha512_hash=salted_sha512_hash,
+        )
 
         # Invalidate cache for user to reflect changes
         with _cache_lock:

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -2366,8 +2366,19 @@ class NotionFileUploader:
             raise Exception(f"Failed to update file metadata: {response.text}")
         return response.json()
 
-    def update_file_security_settings(self, file_id: str, password_hash: str = None, expires_at: str = None) -> Dict[str, Any]:
-        """Update security-related properties for a file entry."""
+    def update_file_security_settings(
+        self,
+        file_id: str,
+        password_hash: str = None,
+        expires_at: str = None,
+        salted_sha512_hash: str = None,
+    ) -> Dict[str, Any]:
+        """Update security-related properties for a file entry.
+
+        Optionally invalidate the cached index entry corresponding to
+        ``salted_sha512_hash`` so that subsequent lookups reflect the
+        new security settings immediately.
+        """
         url = f"{self.base_url}/pages/{file_id}"
         properties: Dict[str, Any] = {}
 
@@ -2389,6 +2400,10 @@ class NotionFileUploader:
         response = requests.patch(url, json=payload, headers=headers)
         if response.status_code != 200:
             raise Exception(f"Failed to update file security settings: {response.text}")
+
+        if salted_sha512_hash:
+            self.invalidate_index_cache(salted_sha512_hash)
+
         return response.json()
 
     def create_folder(self, database_id: str, folder_name: str, parent_path: str = "/") -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- clear cached index entries when updating file security settings
- pass salted SHA512 hash to security update helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfd32a6ab8832fa9af7f94960bd794