### PR TITLE
Use text property for optional share expiration

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,7 +300,7 @@ def build_entries(results: List[Dict[str, Any]], current_folder: str) -> List[Di
             is_folder = properties.get('is_folder', {}).get('checkbox', False)
             is_visible = properties.get('is_visible', {}).get('checkbox', True)
             password_hash = properties.get('password_hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-            expires_at = properties.get('expires_at', {}).get('date', {}).get('start')
+            expires_at = properties.get('expires_at', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
             password_protected = bool(password_hash)
             if name and is_visible and folder_path == current_folder:
                 if is_folder:
@@ -768,7 +768,7 @@ def download_by_hash(salted_sha512_hash):
 
         file_props = file_details.get('properties', {})
         password_hash = file_props.get('password_hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-        expires_at = file_props.get('expires_at', {}).get('date', {}).get('start')
+        expires_at = file_props.get('expires_at', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
 
         if expires_at:
             try:
@@ -1284,7 +1284,7 @@ def get_files_api():
             folder_path = file_props.get('folder_path', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '/')
             salt = file_props.get('salt', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
             password_hash = file_props.get('password_hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-            expires_at = file_props.get('expires_at', {}).get('date', {}).get('start')
+            expires_at = file_props.get('expires_at', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
 
             password_protected = bool(password_hash)
 
@@ -1387,7 +1387,7 @@ def get_entries_api():
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
                 is_visible = properties.get('is_visible', {}).get('checkbox', True)
                 password_hash = _get_prop_text(properties.get('password_hash', {}))
-                expires_at = properties.get('expires_at', {}).get('date', {}).get('start')
+                expires_at = _get_prop_text(properties.get('expires_at', {}))
                 password_protected = bool(password_hash)
 
                 if name and is_visible and folder_path == current_folder:
@@ -1477,7 +1477,7 @@ def search_files_api():
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
                 is_visible = properties.get('is_visible', {}).get('checkbox', True)
                 password_hash = properties.get('password_hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-                expires_at = properties.get('expires_at', {}).get('date', {}).get('start')
+                expires_at = properties.get('expires_at', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
                 password_protected = bool(password_hash)
 
                 if not is_visible:
@@ -1696,7 +1696,7 @@ def update_link_settings():
         # Ensure properties exist in the user's database
         uploader.ensure_database_property(user_database_id, 'is_public', 'checkbox')
         uploader.ensure_database_property(user_database_id, 'password_hash', 'rich_text')
-        uploader.ensure_database_property(user_database_id, 'expires_at', 'date')
+        uploader.ensure_database_property(user_database_id, 'expires_at', 'rich_text')
 
         password_hash = None
         if password is not None:

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -2125,7 +2125,7 @@ class NotionFileUploader:
         # Ensure the is_folder property exists for this database
         self.ensure_database_property(database_id, "is_folder", "checkbox")
         self.ensure_database_property(database_id, "password_hash", "rich_text")
-        self.ensure_database_property(database_id, "expires_at", "date")
+        self.ensure_database_property(database_id, "expires_at", "rich_text")
 
         # CRITICAL FIX 1: Enhanced ID Validation and Logging
         print(f"🔍 ADD_FILE_TO_DB: Starting with file_upload_id: {file_upload_id}")
@@ -2442,7 +2442,7 @@ class NotionFileUploader:
             }
         if expires_at is not None:
             properties["expires_at"] = {
-                "date": {"start": expires_at}
+                "rich_text": [{"text": {"content": expires_at}}]
             }
 
         if not properties:
@@ -2581,7 +2581,7 @@ class NotionFileUploader:
             }
         if expires_at is not None:
             payload["properties"]["Expires At"] = {
-                "date": {"start": expires_at}
+                "rich_text": [{"text": {"content": expires_at}}]
             }
 
         headers = {**self.headers, "Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- treat `expires_at` as a rich text property instead of a date
- parse `expires_at` from rich text so files without an expiry still display
- update security and index helpers to write rich text `expires_at`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe32f1950832fb9c4a6e146bbe9ac