### PR TITLE
Fix rich_text payload for optional password or expiry

### DIFF
--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -2588,12 +2588,16 @@ class NotionFileUploader:
                 "Is Public": {
                     "checkbox": is_public
                 },
-                "Password Hash": {
-                    "rich_text": [{"text": {"content": password_hash}}] if password_hash else {"rich_text": []}
-                },
-                "Expires At": {
-                    "rich_text": [{"text": {"content": expires_at}}] if expires_at else {"rich_text": []}
-                }
+                "Password Hash": (
+                    {"rich_text": [{"text": {"content": password_hash}}]}
+                    if password_hash
+                    else {"rich_text": []}
+                ),
+                "Expires At": (
+                    {"rich_text": [{"text": {"content": expires_at}}]}
+                    if expires_at
+                    else {"rich_text": []}
+                ),
             }
         }
 


### PR DESCRIPTION
## Summary
- correct Notion rich_text property construction for optional Password Hash and Expires At

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfed152d10832f98ace9a0ecb68e16