### PR TITLE
Fix expiration enforcement for naive timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,10 @@ def _enforce_expirations(user_database_id: str, data: Dict[str, Any]) -> None:
             if not (is_public and expires_at):
                 continue
             expiry_dt = datetime.fromisoformat(expires_at)
+            if expiry_dt.tzinfo is None:
+                expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
+            else:
+                expiry_dt = expiry_dt.astimezone(timezone.utc)
             if expiry_dt >= now:
                 continue
             file_id = entry.get('id')


### PR DESCRIPTION
## Summary
- normalize expiration timestamps to UTC so naive inputs are enforced

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01dc49b6c832fb0911249a7da2a8a