### PR TITLE
Require password for view endpoint and adjust content disposition

### DIFF
--- a/templates/password_prompt.html
+++ b/templates/password_prompt.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="container mt-5">
-    <h2>Enter password to download {{ filename }}</h2>
+    <h2>Enter password to {{ action or 'download' }} {{ filename }}</h2>
     {% if error %}
     <div class="alert alert-danger">{{ error }}</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- enforce optional password on /v/<hash> by prompting and validating
- open media inline and force download for other types via Content-Disposition
- generalize password prompt template to handle both viewing and downloading

## Testing
- `pytest`
- `flake8` *(fails: numerous style warnings in uploader modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c2743b6d44832f988541e8cf168b01