### PR TITLE
Fix action column size for file entries

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -308,18 +308,20 @@ function appendEntries(entries) {
                 <td class="folder-column">${entry.folder}</td>
                 <td class="public-link-column">${link}</td>
                 <td class="public-access-column"><label class="switch"><input type="checkbox" class="public-toggle" data-file-id="${entry.id}" data-file-hash="${entry.file_hash || ''}" ${entry.is_public ? 'checked' : ''}><span class="slider round"></span></label></td>
-                <td class="action-buttons">
-                    ${viewContainer}
-                    <a href="/d/${entry.file_hash}" class="btn btn-primary btn-sm"><i class="fas fa-download mr-1"></i>Download</a>
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fas fa-bars"></i>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right">
-                            <button type="button" class="dropdown-item rename-btn" data-file-id="${entry.id}"><i class="fas fa-edit mr-1"></i>Rename</button>
-                            <button type="button" class="dropdown-item move-btn" data-file-id="${entry.id}"><i class="fas fa-folder-open mr-1"></i>Move</button>
-                            <button type="button" class="dropdown-item share-btn" data-file-id="${entry.id}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
-                            <button type="button" class="dropdown-item delete-btn" data-file-id="${entry.id}" data-file-hash="${entry.file_hash || ''}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                <td>
+                    <div class="action-buttons">
+                        ${viewContainer}
+                        <a href="/d/${entry.file_hash}" class="btn btn-primary btn-sm"><i class="fas fa-download mr-1"></i>Download</a>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="fas fa-bars"></i>
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <button type="button" class="dropdown-item rename-btn" data-file-id="${entry.id}"><i class="fas fa-edit mr-1"></i>Rename</button>
+                                <button type="button" class="dropdown-item move-btn" data-file-id="${entry.id}"><i class="fas fa-folder-open mr-1"></i>Move</button>
+                                <button type="button" class="dropdown-item share-btn" data-file-id="${entry.id}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
+                                <button type="button" class="dropdown-item delete-btn" data-file-id="${entry.id}" data-file-hash="${entry.file_hash || ''}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                            </div>
                         </div>
                     </div>
                 </td>`;
@@ -1025,20 +1027,22 @@ function renderEntries(entries) {
                         <span class="slider round"></span>
                     </label>
                 </td>
-                <td class="action-buttons">
-                    ${viewContainer}
-                    <a href="/d/${fileHash}" class="btn btn-primary btn-sm">
-                        <i class="fas fa-download mr-1"></i>Download
-                    </a>
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fas fa-bars"></i>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right">
-                            <button type="button" class="dropdown-item rename-btn" data-file-id="${fileId}"><i class="fas fa-edit mr-1"></i>Rename</button>
-                            <button type="button" class="dropdown-item move-btn" data-file-id="${fileId}"><i class="fas fa-folder-open mr-1"></i>Move</button>
-                            <button type="button" class="dropdown-item share-btn" data-file-id="${fileId}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
-                            <button type="button" class="dropdown-item delete-btn" data-file-id="${fileId}" data-file-hash="${fileHash}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                <td>
+                    <div class="action-buttons">
+                        ${viewContainer}
+                        <a href="/d/${fileHash}" class="btn btn-primary btn-sm">
+                            <i class="fas fa-download mr-1"></i>Download
+                        </a>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="fas fa-bars"></i>
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <button type="button" class="dropdown-item rename-btn" data-file-id="${fileId}"><i class="fas fa-edit mr-1"></i>Rename</button>
+                                <button type="button" class="dropdown-item move-btn" data-file-id="${fileId}"><i class="fas fa-folder-open mr-1"></i>Move</button>
+                                <button type="button" class="dropdown-item share-btn" data-file-id="${fileId}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
+                                <button type="button" class="dropdown-item delete-btn" data-file-id="${fileId}" data-file-hash="${fileHash}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                            </div>
                         </div>
                     </div>
                 </td>

--- a/static/upload.js
+++ b/static/upload.js
@@ -260,14 +260,16 @@ async function loadFiles() {
                             <span class="slider round"></span>
                         </label>
                     </td>
-                    <td class="action-buttons">
-                        <span class="view-button-container" data-filename="${file.name}" data-hash="${saltedHash}" data-filesize="${formatFileSize(file.size)}"></span>
-                        <a href="/d/${saltedHash}" class="btn btn-primary btn-sm">
-                            <i class="fas fa-download mr-1"></i>Download
-                        </a>
-                        <button class="btn btn-danger btn-sm delete-btn" data-file-id="${fileId}">
-                            <i class="fas fa-trash-alt mr-1"></i>Delete
-                        </button>
+                    <td>
+                        <div class="action-buttons">
+                            <span class="view-button-container" data-filename="${file.name}" data-hash="${saltedHash}" data-filesize="${formatFileSize(file.size)}"></span>
+                            <a href="/d/${saltedHash}" class="btn btn-primary btn-sm">
+                                <i class="fas fa-download mr-1"></i>Download
+                            </a>
+                            <button class="btn btn-danger btn-sm delete-btn" data-file-id="${fileId}">
+                                <i class="fas fa-trash-alt mr-1"></i>Delete
+                            </button>
+                        </div>
                     </td>
                 </tr>
             `;

--- a/templates/home.html
+++ b/templates/home.html
@@ -115,22 +115,24 @@
                                 <span class="slider round"></span>
                             </label>
                         </td>
-                        <td class="action-buttons">
-                            {% if entry.file_hash %}
-                            <span class="view-button-container" data-filename="{{ entry.name }}" data-hash="{{ entry.file_hash }}" data-filesize="{{ entry.size | format_bytes }}"></span>
-                            {% endif %}
-                            <a href="{{ url_for('download_by_hash', salted_sha512_hash=entry.file_hash) }}" class="btn btn-primary btn-sm">
-                                <i class="fas fa-download mr-1"></i>Download
-                            </a>
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <i class="fas fa-bars"></i>
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <button type="button" class="dropdown-item rename-btn" data-file-id="{{ entry.id }}"><i class="fas fa-edit mr-1"></i>Rename</button>
-                                    <button type="button" class="dropdown-item move-btn" data-file-id="{{ entry.id }}"><i class="fas fa-folder-open mr-1"></i>Move</button>
-                                    <button type="button" class="dropdown-item share-btn" data-file-id="{{ entry.id }}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
-                                    <button type="button" class="dropdown-item delete-btn" data-file-id="{{ entry.id }}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                        <td>
+                            <div class="action-buttons">
+                                {% if entry.file_hash %}
+                                <span class="view-button-container" data-filename="{{ entry.name }}" data-hash="{{ entry.file_hash }}" data-filesize="{{ entry.size | format_bytes }}"></span>
+                                {% endif %}
+                                <a href="{{ url_for('download_by_hash', salted_sha512_hash=entry.file_hash) }}" class="btn btn-primary btn-sm">
+                                    <i class="fas fa-download mr-1"></i>Download
+                                </a>
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                        <i class="fas fa-bars"></i>
+                                    </button>
+                                    <div class="dropdown-menu dropdown-menu-right">
+                                        <button type="button" class="dropdown-item rename-btn" data-file-id="{{ entry.id }}"><i class="fas fa-edit mr-1"></i>Rename</button>
+                                        <button type="button" class="dropdown-item move-btn" data-file-id="{{ entry.id }}"><i class="fas fa-folder-open mr-1"></i>Move</button>
+                                        <button type="button" class="dropdown-item share-btn" data-file-id="{{ entry.id }}"><i class="fas fa-share-alt mr-1"></i>Share...</button>
+                                        <button type="button" class="dropdown-item delete-btn" data-file-id="{{ entry.id }}"><i class="fas fa-trash-alt mr-1"></i>Delete</button>
+                                    </div>
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
## Summary
- Render file action buttons inside a nested `<div>` so table cells retain consistent width with folder rows
- Update client-side rendering scripts to match new action button markup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c28590edc0832fa0b5bb6eb1e42932