### PR TITLE
fix JSON parsing error when refreshing file list

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -912,12 +912,27 @@ async function loadFiles() {
         console.log('🔍 DIAGNOSTIC: Fetching entry list from /api/entries...');
 
         const folderParam = encodeURIComponent(window.currentFolder || '/');
-        const response = await fetch(`/api/entries?folder=${folderParam}`);
-        if (!response.ok) {
-            throw new Error('Failed to fetch file list');
+        const response = await fetch(`/api/entries?folder=${folderParam}`, {
+            credentials: 'include'
+        });
+
+        if (response.redirected) {
+            window.location.href = response.url;
+            return;
         }
 
-        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(`Failed to fetch file list (${response.status})`);
+        }
+
+        let data;
+        const contentType = response.headers.get('content-type') || '';
+        if (contentType.includes('application/json')) {
+            data = await response.json();
+        } else {
+            const text = await response.text();
+            throw new Error(`Unexpected response: ${text.slice(0, 100)}`);
+        }
         console.log('🔍 DIAGNOSTIC: API Response received:', data);
 
         if (!data.entries) {

--- a/static/upload.js
+++ b/static/upload.js
@@ -187,12 +187,30 @@ async function loadFiles() {
         console.log('Refreshing file list with AJAX...');
         // Fetch the file list data from the API
         const folderParam = encodeURIComponent(window.currentFolder || '/');
-        const response = await fetch(`/files-api?folder=${folderParam}`);
-        if (!response.ok) {
-            throw new Error('Failed to fetch file list');
+        const response = await fetch(`/files-api?folder=${folderParam}`, {
+            credentials: 'include'
+        });
+
+        if (response.redirected) {
+            // If the user was redirected (e.g. session expired), follow the redirect
+            window.location.href = response.url;
+            return;
         }
 
-        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(`Failed to fetch file list (${response.status})`);
+        }
+
+        // Ensure the response is JSON before attempting to parse
+        let data;
+        const contentType = response.headers.get('content-type') || '';
+        if (contentType.includes('application/json')) {
+            data = await response.json();
+        } else {
+            const text = await response.text();
+            throw new Error(`Unexpected response: ${text.slice(0, 100)}`);
+        }
+
         if (!data.files) {
             throw new Error('Invalid response format');
         }


### PR DESCRIPTION
## Summary
- handle unexpected non-JSON responses when refreshing file list
- redirect to login if file list request was redirected

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ee6d1908832f9e018b032346c604