### PR TITLE
Fix manifest total size for range streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,6 +429,11 @@ def fetch_json_from_url(url: str) -> Dict[str, Any]:
         resp.raise_for_status()
         return resp.json() if resp.headers.get('content-type','').startswith('application/json') else json.loads(resp.content)
 
+
+def calculate_manifest_total_size(manifest: Dict[str, Any]) -> int:
+    """Calculate total file size from a manifest's parts array."""
+    return sum(part.get('size', 0) for part in manifest.get('parts', []))
+
 # User class for Flask-Login
 class User(UserMixin):
     def __init__(self, id, username, password_hash):
@@ -857,7 +862,7 @@ def download_by_hash(salted_sha512_hash):
                 manifest = fetch_json_from_url(manifest_url)
                 # Respect the filename stored in Notion so renames are applied
                 orig_name = display_name
-                total_size = manifest.get('total_size', 0)
+                total_size = calculate_manifest_total_size(manifest)
                 # Use video mimetype if possible, fallback to octet-stream
                 import mimetypes
                 mimetype = mimetypes.guess_type(orig_name)[0] or 'application/octet-stream'
@@ -1041,7 +1046,7 @@ def stream_by_hash(salted_sha512_hash):
 
                 # Use the filename from Notion to honor user renames
                 orig_name = display_name
-                total_size = manifest.get('total_size', 0)
+                total_size = calculate_manifest_total_size(manifest)
                 mimetype = mimetypes.guess_type(orig_name)[0] or 'application/octet-stream'
                 disposition = 'inline' if mimetype.startswith(('video/', 'audio/', 'image/')) else 'attachment'
 
@@ -2654,7 +2659,7 @@ def download_multipart_by_page_id(manifest_page_id):
 
         manifest = fetch_json_from_url(manifest_url)
         orig_name = display_name or manifest.get('original_filename', 'download')
-        total_size = manifest.get('total_size', 0)
+        total_size = calculate_manifest_total_size(manifest)
         import mimetypes
         mimetype = mimetypes.guess_type(orig_name)[0] or 'application/octet-stream'
 

--- a/tests/test_manifest_total_size.py
+++ b/tests/test_manifest_total_size.py
@@ -1,0 +1,32 @@
+import sys
+import types
+
+
+# Stub out s3_downloader dependencies required by app import
+s3_dummy = types.ModuleType("s3_downloader")
+def _noop(*args, **kwargs):
+    return None
+s3_dummy.cleanup_stale_streams = _noop
+s3_dummy.download_file = _noop
+s3_dummy.download_file_from_url = _noop
+s3_dummy.stream_file_from_url = _noop
+s3_dummy.stream_file_range_from_url = _noop
+sys.modules["uploader.s3_downloader"] = s3_dummy
+sys.modules["s3_downloader"] = s3_dummy
+
+from app import calculate_manifest_total_size
+
+
+def test_calculate_manifest_total_size_sums_parts():
+    manifest = {
+        'total_size': 9999,
+        'parts': [
+            {'size': 100},
+            {'size': 200},
+            {'size': 300},
+        ]
+    }
+    assert calculate_manifest_total_size(manifest) == 600
+
+def test_calculate_manifest_total_size_empty_parts():
+    assert calculate_manifest_total_size({}) == 0


### PR DESCRIPTION
## Summary
- derive manifest total size from parts to validate byte ranges correctly
- add helper function and tests for manifest size calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67dd67f6c832fa9fdaee717c0042f