### PR TITLE
Support byte-range HEAD requests for video streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -387,6 +387,41 @@ def add_stream_headers(resp, mimetype=''):
         resp.headers.setdefault('Content-Transfer-Encoding', 'binary')
     return resp
 
+
+def parse_byte_range(range_header: str, total_size: int):
+    """Parse a HTTP Range header into a (start, end) tuple.
+
+    Returns ``None`` if the header is malformed or unsatisfiable.
+    """
+    if not range_header:
+        return None
+    range_value = range_header.strip().lower()
+    if '=' not in range_value:
+        return None
+    units, range_spec = range_value.split('=', 1)
+    if units != 'bytes':
+        return None
+    range_start, range_end = range_spec.split('-', 1)
+    try:
+        if range_start and range_end:
+            start = int(range_start)
+            end = int(range_end)
+        elif range_start and not range_end:
+            start = int(range_start)
+            end = total_size - 1
+        elif not range_start and range_end:
+            suffix_length = int(range_end)
+            start = max(0, total_size - suffix_length)
+            end = total_size - 1
+        else:
+            return None
+    except ValueError:
+        return None
+
+    if total_size > 0 and (start < 0 or end >= total_size or start > end):
+        return None
+    return start, end
+
 # Initialize Flask-Login
 login_manager = LoginManager()
 login_manager.init_app(app)
@@ -1051,9 +1086,21 @@ def stream_by_hash(salted_sha512_hash):
                 disposition = 'inline' if mimetype.startswith(('video/', 'audio/', 'image/')) else 'attachment'
 
                 if request.method == 'HEAD':
-                    response = Response(status=200, mimetype=mimetype)
-                    if total_size > 0:
-                        response.headers['Content-Length'] = str(total_size)
+                    range_header = request.headers.get('Range')
+                    if range_header and total_size > 0:
+                        parsed = parse_byte_range(range_header, total_size)
+                        if not parsed:
+                            response = Response(status=416)
+                            response.headers['Content-Range'] = f'bytes */{total_size}'
+                            return response
+                        start, end = parsed
+                        response = Response(status=206, mimetype=mimetype)
+                        response.headers['Content-Length'] = str(end - start + 1)
+                        response.headers['Content-Range'] = f'bytes {start}-{end}/{total_size}'
+                    else:
+                        response = Response(status=200, mimetype=mimetype)
+                        if total_size > 0:
+                            response.headers['Content-Length'] = str(total_size)
                     set_content_disposition(response, disposition, orig_name)
                     return add_stream_headers(response, mimetype)
 
@@ -1185,11 +1232,22 @@ def stream_by_hash(salted_sha512_hash):
         disposition = 'inline' if mimetype.startswith(('video/', 'audio/', 'image/')) else 'attachment'
 
         if request.method == 'HEAD':
-            # Respond with headers only, no body
-            response = Response(status=200, mimetype=mimetype)
+            range_header = request.headers.get('Range')
+            if range_header and file_size > 0:
+                parsed = parse_byte_range(range_header, file_size)
+                if not parsed:
+                    response = Response(status=416)
+                    response.headers['Content-Range'] = f'bytes */{file_size}'
+                    return response
+                start, end = parsed
+                response = Response(status=206, mimetype=mimetype)
+                response.headers['Content-Length'] = str(end - start + 1)
+                response.headers['Content-Range'] = f'bytes {start}-{end}/{file_size}'
+            else:
+                response = Response(status=200, mimetype=mimetype)
+                if file_size > 0:
+                    response.headers['Content-Length'] = str(file_size)
             set_content_disposition(response, disposition, display_name)
-            if file_size > 0:
-                response.headers['Content-Length'] = str(file_size)
             return add_stream_headers(response, mimetype)
 
         # Parse Range header for partial content requests

--- a/tests/test_head_range.py
+++ b/tests/test_head_range.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+s3_dummy = types.ModuleType("s3_downloader")
+def _noop(*args, **kwargs):
+    return None
+s3_dummy.download_file = _noop
+s3_dummy.download_file_from_url = _noop
+s3_dummy.stream_file_from_url = _noop
+s3_dummy.stream_file_range_from_url = _noop
+s3_dummy.cleanup_stale_streams = _noop
+sys.modules["uploader.s3_downloader"] = s3_dummy
+sys.modules["s3_downloader"] = s3_dummy
+
+import app as flask_app
+
+
+class DummyUploader:
+    def get_file_by_salted_sha512_hash(self, hash_value, force_refresh=True):
+        return {
+            'properties': {
+                'Is Public': {'checkbox': True},
+                'File Page ID': {'rich_text': [{'text': {'content': 'page1'}}]},
+                'User Database ID': {'rich_text': [{'text': {'content': 'db1'}}]},
+                'Original Filename': {'title': [{'text': {'content': 'video.mp4'}}]},
+            }
+        }
+
+    def get_user_by_id(self, page_id):
+        return {'properties': {'filename': {'title': [{'text': {'content': 'video.mp4'}}]}}}
+
+
+def fake_fetch_download_metadata(page_id, filename):
+    return {
+        'url': 'http://example.com/video.mp4',
+        'file_size': 1000,
+        'content_type': 'video/mp4',
+    }
+
+
+def test_head_range_returns_partial_headers(monkeypatch):
+    monkeypatch.setattr(flask_app, 'uploader', DummyUploader())
+    monkeypatch.setattr(flask_app, 'fetch_download_metadata', fake_fetch_download_metadata)
+    client = flask_app.app.test_client()
+    resp = client.head('/v/testhash', headers={'Range': 'bytes=100-199'})
+    assert resp.status_code == 206
+    assert resp.headers['Content-Range'] == 'bytes 100-199/1000'
+    assert resp.headers['Content-Length'] == '100'
+    assert resp.headers['Accept-Ranges'] == 'bytes'


### PR DESCRIPTION
## Summary
- handle Range headers for HEAD requests on `/v/<hash>` so media players can seek without downloading the entire file
- add utility to parse byte ranges and reuse across responses
- add regression test for HEAD range handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c680544028832fae5c8102d1edeeb0