### PR TITLE
Improve streaming uploader retry handling

### DIFF
--- a/tests/test_streaming_uploader.py
+++ b/tests/test_streaming_uploader.py
@@ -1,0 +1,161 @@
+import os
+import sys
+import threading
+import types
+from typing import Any, Dict, Optional
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+s3_dummy = types.ModuleType("s3_downloader")
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+s3_dummy.download_file = _noop
+s3_dummy.download_file_from_url = _noop
+s3_dummy.stream_file_from_url = _noop
+s3_dummy.stream_file_range_from_url = _noop
+sys.modules["uploader.s3_downloader"] = s3_dummy
+sys.modules["s3_downloader"] = s3_dummy
+
+import pytest
+
+from uploader.streaming_uploader import NotionStreamingUploader
+
+
+class FakeNotionUploader:
+    def __init__(self, fail_plan: Optional[Dict[str, int]] = None):
+        self.fail_plan = fail_plan or {}
+        self.pages: Dict[str, Dict[str, Any]] = {}
+        self.global_file_index_db_id = None
+        self._lock = threading.Lock()
+
+    def add_file_to_user_database(
+        self,
+        database_id: str,
+        filename: str,
+        file_size: int,
+        file_hash: str,
+        file_upload_id: str,
+        is_public: bool = False,
+        salt: str | None = None,
+        original_filename: str | None = None,
+        file_url: str | None = None,
+        folder_path: str | None = None,
+        is_manifest: bool = False,
+    ) -> Dict[str, Any]:
+        remaining = self.fail_plan.get(filename, 0)
+        if remaining:
+            if remaining == -1:
+                raise RuntimeError("forced failure")
+            self.fail_plan[filename] = remaining - 1
+            raise RuntimeError("transient failure")
+
+        page_id = f"page-{len(self.pages) + 1}-{filename}"
+        entry = {
+            "id": page_id,
+            "properties": {
+                "file_data": {
+                    "files": [
+                        {
+                            "type": "file_upload",
+                            "file_upload": {
+                                "id": file_upload_id,
+                            },
+                        }
+                    ]
+                }
+            },
+        }
+        with self._lock:
+            self.pages[page_id] = entry
+        return entry
+
+    def get_user_by_id(self, page_id: str) -> Dict[str, Any] | None:
+        return self.pages.get(page_id)
+
+    def update_user_properties(self, page_id: str, properties: Dict[str, Any]) -> None:
+        with self._lock:
+            page = self.pages.get(page_id)
+            if not page:
+                return
+            page.setdefault("properties", {}).update(properties)
+
+    def add_file_to_index(self, *args, **kwargs):
+        return None
+
+    def ensure_database_property(self, *args, **kwargs):
+        return None
+
+
+@pytest.fixture
+def uploader(monkeypatch):
+    fake = FakeNotionUploader()
+    uploader = NotionStreamingUploader(api_token="token", notion_uploader=fake)
+    monkeypatch.setattr(NotionStreamingUploader, "SPLIT_THRESHOLD", 4)
+    monkeypatch.setattr(NotionStreamingUploader, "SINGLE_PART_THRESHOLD", 4)
+
+    def fake_worker(self, part_session, chunk_queue, part_size):
+        data = b""
+        while True:
+            chunk = chunk_queue.get()
+            if chunk is None:
+                break
+            data += chunk
+        assert len(data) == part_size
+        return {
+            "file_upload_id": f"upload-{part_session['filename']}",
+            "file_url": f"https://example.com/{part_session['filename']}",
+        }
+
+    def fake_upload_single(self, user_database_id, metadata_filename, stream, size):
+        return {
+            "file_upload_id": "meta-upload",
+            "result": {"file": {"url": "https://example.com/meta"}},
+        }
+
+    monkeypatch.setattr(NotionStreamingUploader, "_upload_part_worker", fake_worker, raising=False)
+    monkeypatch.setattr(NotionStreamingUploader, "_upload_to_notion_single_part", fake_upload_single, raising=False)
+    return uploader, fake
+
+
+def test_process_stream_retries_transient_database_errors(uploader):
+    uploader_instance, fake = uploader
+    fake.fail_plan["bigfile.part1"] = 2
+
+    session = uploader_instance.create_upload_session("bigfile", 8, "db1")
+
+    def stream_gen():
+        yield b"aaaa"
+        yield b"bbbb"
+
+    result = uploader_instance.process_stream(session, stream_gen())
+
+    assert result["status"] == "finalizing"
+    assert result["split"] is True
+    assert len(result["parts"]) == 2
+    assert fake.fail_plan["bigfile.part1"] == 0
+    stored_filenames = {page["id"] for page in fake.pages.values()}
+    assert any("bigfile.part1" in page_id for page_id in stored_filenames)
+    assert any("bigfile.part2" in page_id for page_id in stored_filenames)
+
+
+def test_process_stream_aborts_on_persistent_database_errors(uploader):
+    uploader_instance, fake = uploader
+    fake.fail_plan["bigfile.part1"] = -1
+
+    session = uploader_instance.create_upload_session("bigfile", 8, "db1")
+
+    def stream_gen():
+        yield b"aaaa"
+        yield b"bbbb"
+
+    with pytest.raises(RuntimeError):
+        uploader_instance.process_stream(session, stream_gen())
+
+    # Upload should abort without creating a manifest entry
+    ids = list(fake.pages.keys())
+    assert all(".file.json" not in page_id for page_id in ids)
+    assert all("bigfile.part1" not in page_id for page_id in ids)

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -632,33 +632,68 @@ class NotionStreamingUploader:
         upload loop can continue accepting data without waiting for database
         operations to complete.
         """
-        max_attempts = 3
-        for attempt in range(1, max_attempts + 1):
-            db_entry = self.notion_uploader.add_file_to_user_database(
-                database_id=user_database_id,
-                filename=part_filename,
-                file_size=part_size,
-                file_hash=part_salted_hash,
-                file_upload_id=notion_file_upload_id,
-                is_public=False,
-                salt=part_salt,
-                original_filename=original_filename,
-                file_url=file_url,
-                # Store part entries at root to avoid orphaned parts when moving folders
-                folder_path='/'
-            )
+        max_attempts = 5
+        last_error: Optional[Exception] = None
+        db_entry: Optional[Dict[str, Any]] = None
 
-            if self._validate_file_attachment(db_entry, notion_file_upload_id):
-                break
+        for attempt in range(1, max_attempts + 1):
+            try:
+                db_entry = self.notion_uploader.add_file_to_user_database(
+                    database_id=user_database_id,
+                    filename=part_filename,
+                    file_size=part_size,
+                    file_hash=part_salted_hash,
+                    file_upload_id=notion_file_upload_id,
+                    is_public=False,
+                    salt=part_salt,
+                    original_filename=original_filename,
+                    file_url=file_url,
+                    # Store part entries at root to avoid orphaned parts when moving folders
+                    folder_path='/'
+                )
+            except Exception as exc:
+                last_error = exc
+                print(
+                    f"WARNING: Failed to add part {part_filename} to database (attempt {attempt}/{max_attempts}): {exc}"
+                )
+            else:
+                page_id = db_entry.get('id') if isinstance(db_entry, dict) else None
+                if not page_id:
+                    last_error = Exception(
+                        f"Missing page id for part {part_filename} (attempt {attempt}/{max_attempts})"
+                    )
+                else:
+                    try:
+                        refreshed_entry = self.notion_uploader.get_user_by_id(page_id)
+                        if refreshed_entry:
+                            db_entry = refreshed_entry
+                    except Exception as exc:
+                        last_error = exc
+                        print(
+                            f"WARNING: Failed to refresh part {part_filename} metadata (attempt {attempt}/{max_attempts}): {exc}"
+                        )
+                    else:
+                        if self._validate_file_attachment(db_entry, notion_file_upload_id):
+                            last_error = None
+                            break
+                        last_error = Exception(
+                            f"Validation failed for part {part_filename} (attempt {attempt}/{max_attempts})"
+                        )
+                        print(
+                            f"WARNING: Validation failed for part {part_filename} (attempt {attempt}/{max_attempts}), retrying..."
+                        )
 
             if attempt == max_attempts:
                 raise Exception(
                     f"Failed to attach part {part_filename} after {max_attempts} attempts"
-                )
-            print(
-                f"WARNING: Validation failed for part {part_filename} (attempt {attempt}/{max_attempts}), retrying..."
+                ) from last_error
+
+            time.sleep(0.5 * attempt)
+
+        if db_entry is None:
+            raise Exception(
+                f"Failed to store part {part_filename} metadata after retries"
             )
-            time.sleep(1)
 
         if self.notion_uploader.global_file_index_db_id:
             self.notion_uploader.add_file_to_index(
@@ -772,6 +807,10 @@ class NotionStreamingUploader:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=3) as upload_executor:
                     part_futures: List[concurrent.futures.Future] = []
                     parts_lock = threading.Lock()
+                    callback_errors: List[Exception] = []
+                    callback_errors_lock = threading.Lock()
+                    callback_state = {"completed": 0}
+                    callback_state_lock = threading.Lock()
 
                     def make_callback(idx, part_filename, part_size, part_salted_hash, part_salt):
                         def _callback(fut: concurrent.futures.Future) -> None:
@@ -800,6 +839,11 @@ class NotionStreamingUploader:
                                     })
                             except Exception as e:
                                 print(f"ERROR: Failed to store part {idx} metadata: {e}")
+                                with callback_errors_lock:
+                                    callback_errors.append(e)
+                            finally:
+                                with callback_state_lock:
+                                    callback_state["completed"] += 1
                         return _callback
 
                     for idx, part_size in enumerate(part_sizes, start=1):
@@ -841,7 +885,29 @@ class NotionStreamingUploader:
                         upload_session['last_activity'] = time.time()
 
                     concurrent.futures.wait(part_futures)
+
+                    while True:
+                        with callback_state_lock:
+                            completed_callbacks = callback_state["completed"]
+                        if completed_callbacks >= len(part_futures):
+                            break
+                        time.sleep(0.01)
+
+                    for future in part_futures:
+                        exc = future.exception()
+                        if exc is not None:
+                            raise exc
+
+                    if callback_errors:
+                        first_error = callback_errors[0]
+                        raise RuntimeError("One or more part metadata callbacks failed") from first_error
+
                     parts_metadata.sort(key=lambda x: x["part_number"])
+
+                    if len(parts_metadata) != len(part_sizes):
+                        raise RuntimeError(
+                            "Upload completed but part metadata is incomplete"
+                        )
 
                     if total_uploaded != file_size:
                         raise ValueError(


### PR DESCRIPTION
## Summary
- harden `_store_part_in_database` with multi-attempt retries, refreshed validation, and backoff when Notion writes fail
- ensure concurrent part uploads surface callback failures and mismatched metadata before manifest creation
- add unit tests that simulate transient and persistent Notion database errors during streaming uploads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dfc26cd238832f9f2969bf883da3c9