### PR TITLE
Add curl to Docker image for health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV PORT=80
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first to leverage Docker layer caching


### PR DESCRIPTION
## Summary
- add curl to the Docker image so the Dokploy health check command is available

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e04639ac44832fb34f804ab3595c2a