### PR TITLE
Add curl installation to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PORT=5000
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first to leverage Docker layer caching


### PR DESCRIPTION
## Summary
- include curl in the Docker image so the healthcheck can use it reliably

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e047bd0e9c832f9f6c6975da38011a