### PR TITLE
Add pending upload finalization helper

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -7,6 +7,129 @@
 // Track uploads awaiting database integration before refreshing UI
 window.pendingUploads = window.pendingUploads || new Set();
 
+const PENDING_UPLOAD_POLL_INTERVAL_MS = 2000;
+
+function ensurePendingUploadState() {
+    if (!window.__pendingUploadState) {
+        window.__pendingUploadState = {
+            waiters: [],
+            active: false,
+            timerId: null,
+        };
+    }
+    return window.__pendingUploadState;
+}
+
+function clearPendingUploadTimer() {
+    const state = ensurePendingUploadState();
+    if (state.timerId) {
+        clearTimeout(state.timerId);
+        state.timerId = null;
+    }
+    state.active = false;
+}
+
+function resolvePendingUploadWaiters() {
+    const state = ensurePendingUploadState();
+    const waiters = state.waiters.splice(0, state.waiters.length);
+    clearPendingUploadTimer();
+    waiters.forEach(({ resolve }) => resolve());
+}
+
+function rejectPendingUploadWaiters(error) {
+    const state = ensurePendingUploadState();
+    const waiters = state.waiters.splice(0, state.waiters.length);
+    clearPendingUploadTimer();
+    waiters.forEach(({ reject }) => reject(error));
+}
+
+function updatePendingUploadStatusMessage() {
+    if (!window.pendingUploads || window.pendingUploads.size === 0) {
+        return;
+    }
+    const count = window.pendingUploads.size;
+    const plural = count === 1 ? '' : 's';
+    showStatus(`Waiting for server to finalize ${count} upload${plural}...`, 'info');
+}
+
+async function pollPendingUploadsOnce() {
+    const state = ensurePendingUploadState();
+    if (!window.pendingUploads || window.pendingUploads.size === 0) {
+        resolvePendingUploadWaiters();
+        return;
+    }
+
+    const ids = Array.from(window.pendingUploads);
+    try {
+        await Promise.all(ids.map(async (uploadId) => {
+            const response = await (window.fetch ? window.fetch(`/api/upload/status/${encodeURIComponent(uploadId)}`) : fetch(`/api/upload/status/${encodeURIComponent(uploadId)}`));
+            if (!response.ok) {
+                throw new Error(`Failed to finalize upload ${uploadId}`);
+            }
+            const data = await response.json();
+            if (data.status === 'failed' || data.status === 'error') {
+                const message = data.error || data.message || `Upload ${uploadId} failed to finalize.`;
+                throw new Error(message);
+            }
+            if (data.status === 'completed' || data.status === 'finalized') {
+                window.pendingUploads.delete(uploadId);
+            }
+        }));
+    } catch (error) {
+        rejectPendingUploadWaiters(error);
+        return;
+    }
+
+    if (!window.pendingUploads || window.pendingUploads.size === 0) {
+        resolvePendingUploadWaiters();
+        return;
+    }
+
+    updatePendingUploadStatusMessage();
+
+    state.timerId = setTimeout(() => {
+        pollPendingUploadsOnce().catch(err => {
+            rejectPendingUploadWaiters(err);
+        });
+    }, PENDING_UPLOAD_POLL_INTERVAL_MS);
+}
+
+function finalizePendingUpload(uploadId) {
+    if (!window.pendingUploads) {
+        return;
+    }
+    window.pendingUploads.delete(uploadId);
+    if (window.pendingUploads.size === 0) {
+        resolvePendingUploadWaiters();
+    } else {
+        updatePendingUploadStatusMessage();
+    }
+}
+
+async function waitForPendingUploads() {
+    if (!window.pendingUploads || window.pendingUploads.size === 0) {
+        return;
+    }
+
+    const state = ensurePendingUploadState();
+    updatePendingUploadStatusMessage();
+
+    const promise = new Promise((resolve, reject) => {
+        state.waiters.push({ resolve, reject });
+    });
+
+    if (!state.active) {
+        state.active = true;
+        pollPendingUploadsOnce().catch(err => {
+            rejectPendingUploadWaiters(err);
+        });
+    }
+
+    return promise;
+}
+
+window.waitForPendingUploads = waitForPendingUploads;
+
 // Essential utility functions for UI updates
 function showStatus(message, type) {
     const messageContainer = document.getElementById('messageContainer');
@@ -780,13 +903,16 @@ const uploadFile = async () => {
         uploadForm.reset();
     }
 
-    showStatus('Finalizing uploads...', 'info');
-
-    setTimeout(() => {
+    try {
+        await waitForPendingUploads();
+        showStatus('Uploads finalized and ready to view.', 'success');
         if (progressContainer) {
             progressContainer.innerHTML = '';
         }
-    }, 3000);
+    } catch (error) {
+        console.error('Pending upload finalization failed:', error);
+        showStatus(`Upload finalization failed: ${error.message}`, 'error');
+    }
 };
 
 async function resumeFailedUpload() {
@@ -832,13 +958,64 @@ async function resumeFailedUpload() {
             window.pendingUploads.add(result.upload_id);
         }
         showStatus(`File "${file.name}" uploaded successfully!`, 'success');
-        showStatus('Finalizing uploads...', 'info');
+        try {
+            await waitForPendingUploads();
+            showStatus('Uploads finalized and ready to view.', 'success');
+            const progressContainer = document.getElementById('progressBars');
+            if (progressContainer) {
+                progressContainer.innerHTML = '';
+            }
+        } catch (error) {
+            console.error('Pending upload finalization failed:', error);
+            showStatus(`Upload finalization failed: ${error.message}`, 'error');
+        }
     } catch (error) {
         console.error('Resume upload error:', error);
         showStatus(`Resume failed: ${error.message}`, 'error');
         showRetryButton();
     }
 }
+
+function handleUploadProgressEvent(data) {
+    if (!data) {
+        return;
+    }
+
+    const progressBar = document.getElementById('progressBar');
+    const progressText = document.getElementById('progressText');
+    const progressSubText = document.getElementById('progressSubText');
+
+    if (progressBar && data.percentage !== undefined) {
+        const percentage = Math.min(data.percentage, 95);
+        progressBar.style.width = percentage + '%';
+        if (progressText) {
+            progressText.textContent = percentage.toFixed(0) + '%';
+        }
+
+        if (progressSubText && data.bytes_uploaded !== undefined && data.total_bytes !== undefined) {
+            const uploadedFormatted = formatFileSize(data.bytes_uploaded);
+            const totalFormatted = formatFileSize(data.total_bytes);
+            progressSubText.textContent = `${uploadedFormatted} / ${totalFormatted}`;
+        }
+    }
+
+    if (data.status === 'completed') {
+        updateProgressBar(100, 'Upload complete');
+        if (data.file_id) {
+            showStatus(`File uploaded successfully. ID: ${data.file_id}`, 'success');
+        }
+        if (data.upload_id) {
+            finalizePendingUpload(data.upload_id);
+        }
+        setTimeout(() => {
+            if (typeof loadFiles === 'function') {
+                loadFiles();
+            }
+        }, 500);
+    }
+}
+
+window.handleUploadProgressEvent = handleUploadProgressEvent;
 
 // Initialize when page loads
 document.addEventListener('DOMContentLoaded', function () {

--- a/templates/home.html
+++ b/templates/home.html
@@ -236,33 +236,8 @@
 
         // Socket event handlers for upload progress
         socket.on('upload_progress', function (data) {
-            const progressBar = document.getElementById('progressBar');
-            const progressText = document.getElementById('progressText');
-            const progressSubText = document.getElementById('progressSubText');
-
-            if (progressBar && data.percentage !== undefined) {
-                const percentage = Math.min(data.percentage, 95); // Cap at 95% until finalization
-                progressBar.style.width = percentage + '%';
-                progressText.textContent = percentage.toFixed(0) + '%';
-
-                if (data.bytes_uploaded !== undefined && data.total_bytes !== undefined) {
-                    const uploadedFormatted = formatFileSize(data.bytes_uploaded);
-                    const totalFormatted = formatFileSize(data.total_bytes);
-                    progressSubText.textContent = `${uploadedFormatted} / ${totalFormatted}`;
-                }
-            }
-
-            if (data.status === 'completed') {
-                updateProgressBar(100, 'Upload complete');
-                showStatus(`File uploaded successfully. ID: ${data.file_id}`, 'success');
-                if (data.upload_id && window.pendingUploads) {
-                    window.pendingUploads.delete(data.upload_id);
-                }
-                setTimeout(() => {
-                    if (typeof loadFiles === 'function') {
-                        loadFiles();
-                    }
-                }, 500);
+            if (typeof window.handleUploadProgressEvent === 'function') {
+                window.handleUploadProgressEvent(data);
             }
         });
 

--- a/tests/test_wait_for_pending_uploads.py
+++ b/tests/test_wait_for_pending_uploads.py
@@ -1,0 +1,140 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_wait_for_pending_uploads(tmp_path):
+    project_root = Path(__file__).resolve().parents[1]
+    streaming_js = project_root / "static" / "streaming-upload.js"
+
+    node_script = f"""
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('{streaming_js.as_posix()}', 'utf8');
+
+const messageLog = [];
+const messageContainer = {{
+    innerHTML: '',
+    appendChild(node) {{
+        node.parentNode = this;
+        messageLog.push(node.innerHTML);
+    }},
+    removeChild(node) {{
+        const idx = messageLog.indexOf(node.innerHTML);
+        if (idx >= 0) {{
+            messageLog.splice(idx, 1);
+        }}
+    }},
+}};
+
+const progressContainer = {{
+    innerHTML: '<div>progress</div>',
+}};
+
+const createStubElement = () => {{
+    return {{
+        style: {{}},
+        textContent: '',
+        innerHTML: '',
+        appendChild() {{}},
+        removeChild() {{}},
+    }};
+}};
+
+const context = {{
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+}};
+
+context.window = context;
+context.window.pendingUploads = new Set();
+context.window.currentFolder = '/';
+context.window.location = {{ origin: 'http://localhost' }};
+context.document = {{
+    getElementById(id) {{
+        if (id === 'messageContainer') {{
+            return messageContainer;
+        }}
+        if (id === 'progressBars') {{
+            return progressContainer;
+        }}
+        return createStubElement();
+    }},
+    createElement(tag) {{
+        return {{
+            tagName: tag,
+            className: '',
+            innerHTML: '',
+            style: {{}},
+            appendChild(child) {{
+                this.child = child;
+            }},
+        }};
+    }},
+    querySelectorAll() {{
+        return [];
+    }},
+    addEventListener() {{
+        return undefined;
+    }},
+}};
+
+vm.createContext(context);
+vm.runInContext(code, context);
+
+const results = {{
+    messageLog: messageLog,
+    progressBefore: progressContainer.innerHTML,
+    progressAfter: null,
+    pendingCount: null,
+    fetchCount: 0,
+    error: null,
+}};
+
+context.window.fetch = async (url) => {{
+    results.fetchCount += 1;
+    return {{
+        ok: true,
+        json: async () => ({{ status: 'completed' }}),
+    }};
+}};
+
+(async () => {{
+    context.window.pendingUploads.add('upload-1');
+    try {{
+        await context.window.waitForPendingUploads();
+        progressContainer.innerHTML = '';
+        results.pendingCount = context.window.pendingUploads.size;
+    }} catch (err) {{
+        results.error = err.message;
+    }}
+    results.progressAfter = progressContainer.innerHTML;
+    console.log(JSON.stringify(results));
+}})().catch((err) => {{
+    results.error = err.message;
+    results.progressAfter = progressContainer.innerHTML;
+    console.log(JSON.stringify(results));
+}});
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output_line = completed.stdout.strip().splitlines()[-1]
+    data = json.loads(output_line)
+
+    assert data["error"] is None
+    assert data["fetchCount"] >= 1
+    assert data["pendingCount"] == 0
+    assert data["progressBefore"] != ''
+    assert data["progressAfter"] == ''
+    assert any(
+        'Waiting for server to finalize' in message
+        for message in data["messageLog"]
+    ), data["messageLog"]


### PR DESCRIPTION
## Summary
- add a waitForPendingUploads helper that polls upload status, merges socket completions, and shares logic through a global handler
- update upload flows to await finalization before clearing progress bars and exposing the socket notifier
- add regression coverage that exercises the helper without sockets via a Node-based test harness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e06069ce54832fa14793e0958cec43