### PR TITLE
Handle success status in pending upload polling

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -71,7 +71,7 @@ async function pollPendingUploadsOnce() {
                 const message = data.error || data.message || `Upload ${uploadId} failed to finalize.`;
                 throw new Error(message);
             }
-            if (data.status === 'completed' || data.status === 'finalized') {
+            if (data.status === 'completed' || data.status === 'finalized' || data.status === 'success') {
                 window.pendingUploads.delete(uploadId);
             }
         }));

--- a/tests/test_wait_for_pending_uploads.py
+++ b/tests/test_wait_for_pending_uploads.py
@@ -97,7 +97,7 @@ context.window.fetch = async (url) => {{
     results.fetchCount += 1;
     return {{
         ok: true,
-        json: async () => ({{ status: 'completed' }}),
+        json: async () => ({{ status: 'success' }}),
     }};
 }};
 


### PR DESCRIPTION
## Summary
- treat upload status `success` as a terminal state in the polling helper so pending uploads are cleared
- adjust wait-for-pending-uploads test to simulate a success response from the status endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e06638b64c832fbeed249c9ec38519