### PR TITLE
Improve streaming uploader backpressure handling

### DIFF
--- a/tests/test_streaming_uploader.py
+++ b/tests/test_streaming_uploader.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import time
 import types
 from typing import Any, Dict, Optional
 
@@ -97,7 +98,9 @@ def uploader(monkeypatch):
     monkeypatch.setattr(NotionStreamingUploader, "SPLIT_THRESHOLD", 4)
     monkeypatch.setattr(NotionStreamingUploader, "SINGLE_PART_THRESHOLD", 4)
 
-    def fake_worker(self, part_session, chunk_queue, part_size):
+    def fake_worker(self, part_session, chunk_queue, part_size, start_event=None):
+        if start_event is not None:
+            start_event.set()
         data = b""
         while True:
             chunk = chunk_queue.get()
@@ -159,3 +162,68 @@ def test_process_stream_aborts_on_persistent_database_errors(uploader):
     ids = list(fake.pages.keys())
     assert all(".file.json" not in page_id for page_id in ids)
     assert all("bigfile.part1" not in page_id for page_id in ids)
+
+
+def test_streaming_uploader_waits_for_available_workers(monkeypatch):
+    fake = FakeNotionUploader()
+    uploader = NotionStreamingUploader(api_token="token", notion_uploader=fake)
+    monkeypatch.setattr(NotionStreamingUploader, "SPLIT_THRESHOLD", 4)
+    monkeypatch.setattr(NotionStreamingUploader, "SINGLE_PART_THRESHOLD", 4)
+
+    active = 0
+    max_active = 0
+    active_lock = threading.Lock()
+    processed_parts: list[str] = []
+
+    def slow_worker(self, part_session, chunk_queue, part_size, start_event=None):
+        nonlocal active, max_active
+        if start_event is not None:
+            start_event.set()
+        local_total = 0
+        with active_lock:
+            active += 1
+            max_active = max(max_active, active)
+        try:
+            while True:
+                chunk = chunk_queue.get()
+                if chunk is None:
+                    break
+                local_total += len(chunk)
+                time.sleep(0.05)
+            assert local_total == part_size
+            processed_parts.append(part_session["filename"])
+            return {
+                "file_upload_id": f"upload-{part_session['filename']}",
+                "file_url": f"https://example.com/{part_session['filename']}",
+            }
+        finally:
+            with active_lock:
+                active -= 1
+
+    monkeypatch.setattr(NotionStreamingUploader, "_upload_part_worker", slow_worker, raising=False)
+    monkeypatch.setattr(
+        NotionStreamingUploader,
+        "_upload_to_notion_single_part",
+        lambda self, user_database_id, metadata_filename, stream, size: {
+            "file_upload_id": "meta-upload",
+            "result": {"file": {"url": "https://example.com/meta"}},
+        },
+        raising=False,
+    )
+
+    total_parts = 5
+    part_size = 4
+    session = uploader.create_upload_session("slowfile", total_parts * part_size, "db1")
+
+    def stream_gen():
+        for idx in range(total_parts):
+            yield bytes([97 + (idx % 26)]) * part_size
+
+    result = uploader.process_stream(session, stream_gen())
+
+    assert result["status"] == "finalizing"
+    assert result["split"] is True
+    assert len(result["parts"]) == total_parts
+    assert len(processed_parts) == total_parts
+    assert max_active <= 3
+    assert active == 0

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -11,7 +11,7 @@ import time
 import hashlib
 import uuid
 import secrets
-from typing import Optional, Callable, Dict, Any, List
+from typing import Optional, Callable, Dict, Any, List, Set
 import concurrent.futures
 import queue
 import requests
@@ -735,6 +735,7 @@ class NotionStreamingUploader:
         part_session: Dict[str, Any],
         chunk_queue: queue.Queue,
         part_size: int,
+        start_event: Optional[threading.Event] = None,
     ) -> Dict[str, str]:
         """Upload a part by streaming bytes from ``chunk_queue``.
 
@@ -742,6 +743,9 @@ class NotionStreamingUploader:
         worker consumes them and uploads to Notion. It returns the Notion file
         upload ID and resulting file URL so the caller can persist metadata
         once the hash is known."""
+
+        if start_event is not None:
+            start_event.set()
 
         def file_generator():
             while True:
@@ -806,6 +810,8 @@ class NotionStreamingUploader:
                 # finish for each part.
                 with concurrent.futures.ThreadPoolExecutor(max_workers=3) as upload_executor:
                     part_futures: List[concurrent.futures.Future] = []
+                    inflight_futures: Set[concurrent.futures.Future] = set()
+                    executor_max_workers = getattr(upload_executor, "_max_workers", 1) or 1
                     parts_lock = threading.Lock()
                     callback_errors: List[Exception] = []
                     callback_errors_lock = threading.Lock()
@@ -847,17 +853,36 @@ class NotionStreamingUploader:
                         return _callback
 
                     for idx, part_size in enumerate(part_sizes, start=1):
+                        inflight_futures = {f for f in inflight_futures if not f.done()}
+                        while len(inflight_futures) >= executor_max_workers:
+                            _, not_done = concurrent.futures.wait(
+                                inflight_futures,
+                                return_when=concurrent.futures.FIRST_COMPLETED,
+                            )
+                            inflight_futures = set(not_done)
+
                         part_filename = f"{filename}.part{idx}"
                         part_session = self.create_upload_session(part_filename, part_size, user_database_id)
                         part_stream = self._PartStream(stream_iter, part_size, leftover, upload_session['hasher'])
 
                         chunk_queue: queue.Queue = queue.Queue(maxsize=4)
+                        worker_started = threading.Event()
                         future = upload_executor.submit(
                             self._upload_part_worker,
                             part_session,
                             chunk_queue,
                             part_size,
+                            worker_started,
                         )
+
+                        inflight_futures.add(future)
+                        part_futures.append(future)
+
+                        while not worker_started.wait(timeout=0.1):
+                            if future.done():
+                                # Propagate errors if the worker failed before signaling readiness.
+                                future.result()
+                                break
 
                         for chunk in part_stream:
                             chunk_queue.put(chunk)
@@ -881,7 +906,6 @@ class NotionStreamingUploader:
                         future.add_done_callback(
                             make_callback(idx, part_filename, part_size, part_salted_hash, part_salt)
                         )
-                        part_futures.append(future)
                         upload_session['last_activity'] = time.time()
 
                     concurrent.futures.wait(part_futures)


### PR DESCRIPTION
## Summary
- gate new part uploads until an executor worker is available and signal worker readiness before pushing chunks
- update the streaming uploader worker to support a start handshake
- add a regression test that exercises slow multipart uploads exceeding the worker pool size

## Testing
- pytest tests/test_streaming_uploader.py

------
https://chatgpt.com/codex/tasks/task_e_68e073803ffc832fb041ec6e0268cb75