### PR TITLE
Ensure load_user refreshes cached credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -512,20 +512,8 @@ class User(UserMixin):
 @login_manager.user_loader
 def load_user(user_id):
     cached = get_cached_user_credentials(user_id)
-    if cached:
-        return User(
-            id=user_id,
-            username=cached.get("username", ""),
-            password_hash=cached.get("password_hash", ""),
-        )
-
     try:
         user_data = uploader.get_user_by_id(user_id)
-        if user_data:
-            username = user_data.get('properties', {}).get('Name', {}).get('title', [{}])[0].get('text', {}).get('content', '')
-            password_hash = user_data.get('properties', {}).get('Password-Hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
-            cache_user_credentials(user_id, username, password_hash)
-            return User(id=user_id, username=username, password_hash=password_hash)
     except Exception as e:
         if cached:
             app.logger.warning("Failed to refresh user %s from Notion, using cached credentials: %s", user_id, e)
@@ -535,7 +523,17 @@ def load_user(user_id):
                 password_hash=cached.get("password_hash", ""),
             )
         app.logger.error("Error loading user %s: %s", user_id, e)
-    return None
+        return None
+
+    if not user_data:
+        if cached:
+            clear_user_credentials(user_id)
+        return None
+
+    username = user_data.get('properties', {}).get('Name', {}).get('title', [{}])[0].get('text', {}).get('content', '')
+    password_hash = user_data.get('properties', {}).get('Password-Hash', {}).get('rich_text', [{}])[0].get('text', {}).get('content', '')
+    cache_user_credentials(user_id, username, password_hash)
+    return User(id=user_id, username=username, password_hash=password_hash)
 
 @app.route('/')
 @login_required

--- a/tests/test_streaming_uploader.py
+++ b/tests/test_streaming_uploader.py
@@ -20,6 +20,7 @@ s3_dummy.download_file = _noop
 s3_dummy.download_file_from_url = _noop
 s3_dummy.stream_file_from_url = _noop
 s3_dummy.stream_file_range_from_url = _noop
+s3_dummy.cleanup_stale_streams = _noop
 sys.modules["uploader.s3_downloader"] = s3_dummy
 sys.modules["s3_downloader"] = s3_dummy
 
@@ -264,5 +265,107 @@ def test_load_user_returns_cached_user_on_notion_error(monkeypatch):
         assert user.id == user_id
         assert user.username == username
         assert user.password_hash == password_hash
+    finally:
+        clear_user_credentials(user_id)
+
+
+def test_load_user_refreshes_cached_credentials(monkeypatch):
+    if "app" in sys.modules:
+        app_module = sys.modules["app"]
+    else:
+        class _NoopTimer:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr(threading, "Timer", lambda *args, **kwargs: _NoopTimer(*args, **kwargs))
+        app_module = importlib.import_module("app")
+
+    cache_user_credentials = app_module.cache_user_credentials
+    clear_user_credentials = app_module.clear_user_credentials
+    get_cached_user_credentials = app_module.get_cached_user_credentials
+
+    user_id = "user-456"
+    cached_username = "old-alice"
+    cached_hash = base64.b64encode(b"old-secret").decode("utf-8")
+    cache_user_credentials(user_id, cached_username, cached_hash)
+
+    refreshed_username = "new-alice"
+    refreshed_hash = base64.b64encode(b"new-secret").decode("utf-8")
+    user_data = {
+        "properties": {
+            "Name": {
+                "title": [
+                    {
+                        "text": {
+                            "content": refreshed_username,
+                        }
+                    }
+                ]
+            },
+            "Password-Hash": {
+                "rich_text": [
+                    {
+                        "text": {
+                            "content": refreshed_hash,
+                        }
+                    }
+                ]
+            },
+        }
+    }
+
+    calls = []
+
+    def fake_get_user_by_id(requested_user_id):
+        calls.append(requested_user_id)
+        return user_data
+
+    monkeypatch.setattr(app_module.uploader, "get_user_by_id", fake_get_user_by_id)
+
+    try:
+        user = app_module.load_user(user_id)
+        assert calls == [user_id]
+        assert user is not None
+        assert user.username == refreshed_username
+        assert user.password_hash == refreshed_hash
+        cached = get_cached_user_credentials(user_id)
+        assert cached["username"] == refreshed_username
+        assert cached["password_hash"] == refreshed_hash
+    finally:
+        clear_user_credentials(user_id)
+
+
+def test_load_user_respects_deletion(monkeypatch):
+    if "app" in sys.modules:
+        app_module = sys.modules["app"]
+    else:
+        class _NoopTimer:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr(threading, "Timer", lambda *args, **kwargs: _NoopTimer(*args, **kwargs))
+        app_module = importlib.import_module("app")
+
+    cache_user_credentials = app_module.cache_user_credentials
+    clear_user_credentials = app_module.clear_user_credentials
+    get_cached_user_credentials = app_module.get_cached_user_credentials
+
+    user_id = "user-789"
+    username = "bob"
+    password_hash = base64.b64encode(b"password").decode("utf-8")
+    cache_user_credentials(user_id, username, password_hash)
+
+    monkeypatch.setattr(app_module.uploader, "get_user_by_id", lambda uid: None)
+
+    try:
+        user = app_module.load_user(user_id)
+        assert user is None
+        assert get_cached_user_credentials(user_id) is None
     finally:
         clear_user_credentials(user_id)


### PR DESCRIPTION
## Summary
- always attempt to refresh user credentials from Notion during user load
- fall back to cached credentials only when the Notion lookup fails and clear stale cache entries
- expand tests to cover credential refresh, deletion handling, and required s3 downloader stubs

## Testing
- pytest tests/test_streaming_uploader.py -k load_user

------
https://chatgpt.com/codex/tasks/task_e_68e2b6a132f0832f83d2170affaa6a97