### PR TITLE
Clear cached credentials after Notion user deletion errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ import uuid
 import random
 import string
 import json
+import re
 from flask_socketio import emit
 from collections import defaultdict
 import gc
@@ -161,6 +162,26 @@ def clear_user_credentials(user_id: Optional[str] = None) -> None:
             _user_auth_cache.clear()
         else:
             _user_auth_cache.pop(user_id, None)
+
+
+_HTTP_STATUS_RE = re.compile(r"HTTP\s+(\d{3})")
+
+
+def _extract_http_status_code(exc: Exception) -> Optional[int]:
+    """Attempt to extract an HTTP status code from an exception."""
+
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+
+    match = _HTTP_STATUS_RE.search(str(exc))
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+    return None
 
 def _purge_stale_cache_locked():
     """Remove expired cache entries and enforce size limit."""
@@ -515,7 +536,10 @@ def load_user(user_id):
     try:
         user_data = uploader.get_user_by_id(user_id)
     except Exception as e:
+        status_code = _extract_http_status_code(e)
         if cached:
+            if status_code in {404, 410}:
+                clear_user_credentials(user_id)
             app.logger.warning("Failed to refresh user %s from Notion, using cached credentials: %s", user_id, e)
             return User(
                 id=user_id,

--- a/tests/test_streaming_uploader.py
+++ b/tests/test_streaming_uploader.py
@@ -247,6 +247,7 @@ def test_load_user_returns_cached_user_on_notion_error(monkeypatch):
 
     cache_user_credentials = app_module.cache_user_credentials
     clear_user_credentials = app_module.clear_user_credentials
+    get_cached_user_credentials = app_module.get_cached_user_credentials
 
     user_id = "user-123"
     username = "alice"
@@ -265,6 +266,8 @@ def test_load_user_returns_cached_user_on_notion_error(monkeypatch):
         assert user.id == user_id
         assert user.username == username
         assert user.password_hash == password_hash
+        cached = get_cached_user_credentials(user_id)
+        assert cached is not None
     finally:
         clear_user_credentials(user_id)
 
@@ -366,6 +369,43 @@ def test_load_user_respects_deletion(monkeypatch):
     try:
         user = app_module.load_user(user_id)
         assert user is None
+        assert get_cached_user_credentials(user_id) is None
+    finally:
+        clear_user_credentials(user_id)
+
+
+def test_load_user_clears_cache_on_notion_not_found(monkeypatch):
+    if "app" in sys.modules:
+        app_module = sys.modules["app"]
+    else:
+        class _NoopTimer:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr(threading, "Timer", lambda *args, **kwargs: _NoopTimer(*args, **kwargs))
+        app_module = importlib.import_module("app")
+
+    cache_user_credentials = app_module.cache_user_credentials
+    clear_user_credentials = app_module.clear_user_credentials
+    get_cached_user_credentials = app_module.get_cached_user_credentials
+
+    user_id = "user-404"
+    username = "carol"
+    password_hash = base64.b64encode(b"pw").decode("utf-8")
+    cache_user_credentials(user_id, username, password_hash)
+
+    def raiser(*args, **kwargs):
+        raise Exception("Failed to get user by ID: HTTP 404 - not found")
+
+    monkeypatch.setattr(app_module.uploader, "get_user_by_id", raiser)
+
+    try:
+        user = app_module.load_user(user_id)
+        assert user is not None
+        assert user.id == user_id
         assert get_cached_user_credentials(user_id) is None
     finally:
         clear_user_credentials(user_id)


### PR DESCRIPTION
## Summary
- extract HTTP status codes from Notion API failures when loading a user
- clear cached credentials when the API reports that a user page no longer exists
- add regression coverage to ensure caches persist on transient errors and are removed on 404 responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2b7fcb698832fab121d627c9f8b81