### PR TITLE
Fix retry limit handling after throttling

### DIFF
--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -733,7 +733,7 @@ class NotionStreamingUploader:
             throttle_encountered = throttle_encountered or is_throttled
             attempt_limit = throttle_attempt_limit if throttle_encountered else base_attempt_limit
 
-            if not is_throttled and attempt >= base_attempt_limit:
+            if not throttle_encountered and attempt >= base_attempt_limit:
                 print(
                     f"WARNING: Giving up on attaching part {part_filename} after {base_attempt_limit} attempts"
                 )


### PR DESCRIPTION
## Summary
- ensure the base attempt limit check is skipped once throttling has been encountered so retries can continue up to the higher limit

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e526c4ca0c832fa382ad17ce9363d7