### PR TITLE
Prevent cleanup thread from blocking uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,12 +52,15 @@ def cleanup_old_sessions():
     """Clean up old upload sessions every minute"""
     try:
         current_time = time.time()
+        manager = globals().get('streaming_upload_manager')
+        expired_sessions: List[Dict[str, Any]] = []
+        streaming_sessions = 0
 
-        if 'streaming_upload_manager' in globals():
+        if manager is not None:
             try:
-                with streaming_upload_manager.upload_lock:
+                with manager.upload_lock:
                     expired_uploads = []
-                    for upload_id, session in streaming_upload_manager.active_uploads.items():
+                    for upload_id, session in list(manager.active_uploads.items()):
                         status = session.get('status')
                         last_activity = session.get('last_activity', session.get('created_at', 0))
                         if status == 'completed':
@@ -73,25 +76,39 @@ def cleanup_old_sessions():
                             timeout = 900  # 15 minutes for active sessions
 
                         if current_time - last_activity > timeout:
-                            expired_uploads.append((upload_id, status))
+                            expired_uploads.append((upload_id, session))
 
-                    for upload_id, status in expired_uploads:
-                        session = streaming_upload_manager.active_uploads.pop(upload_id, None)
-                        streaming_upload_manager.session_locks.pop(upload_id, None)
-                        if session:
-                            for part_id in session.get('uploaded_parts', []):
-                                try:
-                                    streaming_upload_manager.uploader.notion_uploader.delete_file_from_user_database(part_id)
-                                    if streaming_upload_manager.uploader.notion_uploader.global_file_index_db_id:
-                                        streaming_upload_manager.uploader.notion_uploader.delete_file_from_index(part_id)
-                                    print(f"Deleted orphan part: {part_id}")
-                                except Exception as e:
-                                    print(f"Error deleting orphan part {part_id}: {e}")
-                        print(f"Cleaned up {status or 'stalled'} upload session: {upload_id}")
+                    for upload_id, session in expired_uploads:
+                        removed_session = manager.active_uploads.pop(upload_id, None)
+                        manager.session_locks.pop(upload_id, None)
+                        if removed_session:
+                            expired_sessions.append({
+                                'upload_id': upload_id,
+                                'status': removed_session.get('status'),
+                                'uploaded_parts': list(removed_session.get('uploaded_parts', []))
+                            })
+                    streaming_sessions = len(manager.active_uploads)
             except Exception as e:
                 print(f"Error cleaning streaming uploads: {e}")
 
-        streaming_sessions = len(streaming_upload_manager.active_uploads) if 'streaming_upload_manager' in globals() else 0
+        notion_uploader = None
+        if manager is not None:
+            notion_uploader = getattr(manager.uploader, 'notion_uploader', None)
+
+        for session in expired_sessions:
+            status_label = session.get('status') or 'stalled'
+            for part_id in session.get('uploaded_parts', []):
+                if not notion_uploader:
+                    break
+                try:
+                    notion_uploader.delete_file_from_user_database(part_id)
+                    if getattr(notion_uploader, 'global_file_index_db_id', None):
+                        notion_uploader.delete_file_from_index(part_id)
+                    print(f"Deleted orphan part: {part_id}")
+                except Exception as e:
+                    print(f"Error deleting orphan part {part_id}: {e}")
+            print(f"Cleaned up {status_label} upload session: {session.get('upload_id')}")
+
         print(f"SESSION_CLEANUP: Active streaming sessions: {streaming_sessions}")
 
     except Exception as e:

--- a/tests/test_cleanup_thread.py
+++ b/tests/test_cleanup_thread.py
@@ -1,0 +1,136 @@
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_cleanup_does_not_block_active_uploads(monkeypatch):
+    import sys
+
+    # Ensure clean imports for the heavily patched app module
+    for name in [
+        "app",
+        "uploader",
+        "uploader.streaming_uploader",
+        "uploader.s3_downloader",
+    ]:
+        sys.modules.pop(name, None)
+
+    fake_uploader = ModuleType("uploader")
+    fake_uploader.__path__ = []  # Mark as package for submodule imports
+
+    class DummyNotionFileUploader:
+        def __init__(self, *args, **kwargs):
+            self.notion_uploader = SimpleNamespace(
+                delete_file_from_user_database=lambda part_id: None,
+                delete_file_from_index=lambda part_id: None,
+                global_file_index_db_id=None,
+            )
+
+    class DummyChunkProcessor:
+        pass
+
+    class DummyStreamingUploadManager:
+        def __init__(self, *args, **kwargs):
+            self.upload_lock = threading.Lock()
+            self.active_uploads = {}
+            self.session_locks = {}
+            notion_uploader = kwargs.get("notion_uploader")
+            if notion_uploader is None:
+                notion_uploader = SimpleNamespace(
+                    notion_uploader=SimpleNamespace(
+                        delete_file_from_user_database=lambda part_id: None,
+                        delete_file_from_index=lambda part_id: None,
+                        global_file_index_db_id=None,
+                    )
+                )
+            self.uploader = notion_uploader
+
+    fake_streaming_module = ModuleType("uploader.streaming_uploader")
+    fake_streaming_module.StreamingUploadManager = DummyStreamingUploadManager
+    fake_streaming_module.NotionStreamingUploader = object
+
+    fake_s3_module = ModuleType("uploader.s3_downloader")
+    fake_s3_module.cleanup_stale_streams = lambda: None
+    fake_s3_module.download_file_from_url = lambda *args, **kwargs: None
+
+    fake_uploader.NotionFileUploader = DummyNotionFileUploader
+    fake_uploader.ChunkProcessor = DummyChunkProcessor
+    fake_uploader.download_s3_file_from_url = lambda *args, **kwargs: None
+    fake_uploader.StreamingUploadManager = DummyStreamingUploadManager
+
+    monkeypatch.setitem(sys.modules, "uploader", fake_uploader)
+    monkeypatch.setitem(sys.modules, "uploader.streaming_uploader", fake_streaming_module)
+    monkeypatch.setitem(sys.modules, "uploader.s3_downloader", fake_s3_module)
+
+    import app
+
+    class DummyTimer:
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+
+        def start(self):
+            return self
+
+    monkeypatch.setattr(app.threading, "Timer", lambda interval, func: DummyTimer(interval, func))
+    monkeypatch.setattr(app, "cleanup_stale_streams", lambda: None)
+
+    slow_delete_started = threading.Event()
+    allow_delete_to_finish = threading.Event()
+
+    class SlowNotionCleaner:
+        global_file_index_db_id = None
+
+        def delete_file_from_user_database(self, part_id):
+            slow_delete_started.set()
+            # Block until the test signals that cleanup work can finish
+            allow_delete_to_finish.wait(timeout=2)
+
+        def delete_file_from_index(self, part_id):
+            pass
+
+    fake_manager = SimpleNamespace(
+        upload_lock=threading.Lock(),
+        active_uploads={},
+        session_locks={}
+    )
+
+    expired_session = {
+        "status": "completed",
+        "uploaded_parts": ["part-1"],
+        "completed_at": time.time() - 120,
+        "created_at": time.time() - 120,
+    }
+
+    fake_manager.active_uploads["expired"] = expired_session
+    fake_manager.uploader = SimpleNamespace(notion_uploader=SlowNotionCleaner())
+
+    monkeypatch.setattr(app, "streaming_upload_manager", fake_manager, raising=False)
+
+    cleanup_thread = threading.Thread(target=app.cleanup_old_sessions)
+    cleanup_thread.start()
+
+    upload_lock_acquired = threading.Event()
+
+    def simulate_upload():
+        slow_delete_started.wait()
+        with fake_manager.upload_lock:
+            upload_lock_acquired.set()
+
+    uploader_thread = threading.Thread(target=simulate_upload)
+    uploader_thread.start()
+
+    try:
+        assert slow_delete_started.wait(timeout=1), "Cleanup did not reach deletion step"
+        assert upload_lock_acquired.wait(timeout=0.2), "Upload thread blocked waiting for cleanup"
+    finally:
+        allow_delete_to_finish.set()
+        cleanup_thread.join(timeout=1)
+        uploader_thread.join(timeout=1)
+
+    assert "expired" not in fake_manager.active_uploads


### PR DESCRIPTION
## Summary
- release the streaming upload manager lock before performing slow cleanup work
- keep orphan part deletion and GC outside the critical section to avoid upload stalls
- add a regression test covering cleanup timing with mocked slow deletion

## Testing
- pytest tests/test_cleanup_thread.py

------
https://chatgpt.com/codex/tasks/task_e_68e554e4412c832fa9002f41a4ca8fe9