### PR TITLE
Add delayed orphan cleanup for aborted uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,12 @@ def cleanup_old_sessions():
                         removed_session = manager.active_uploads.pop(upload_id, None)
                         manager.session_locks.pop(upload_id, None)
                         if removed_session:
+                            timer = removed_session.get('_orphan_cleanup_timer')
+                            if timer:
+                                try:
+                                    timer.cancel()
+                                except Exception:
+                                    pass
                             expired_sessions.append({
                                 'upload_id': upload_id,
                                 'status': removed_session.get('status'),
@@ -116,7 +122,15 @@ def cleanup_old_sessions():
     cleanup_stale_streams()
     gc.collect()
     # Schedule next check
-    threading.Timer(60, cleanup_old_sessions).start()
+    try:
+        next_timer = threading.Timer(60, cleanup_old_sessions)
+        try:
+            next_timer.daemon = True
+        except Exception:
+            pass
+        next_timer.start()
+    except Exception as timer_error:
+        print(f"Error scheduling session cleanup timer: {timer_error}")
     
 # Load environment variables from .env file
 load_dotenv()
@@ -503,6 +517,12 @@ uploader = NotionFileUploader(
     socketio=socketio,
     global_file_index_db_id=GLOBAL_FILE_INDEX_DB_ID
 )
+
+if not hasattr(uploader, 'get_user_by_id'):
+    def _missing_get_user_by_id(*args, **kwargs):
+        raise NotImplementedError("get_user_by_id is not implemented on the configured uploader")
+
+    setattr(uploader, 'get_user_by_id', _missing_get_user_by_id)
 
 # Initialize streaming upload manager
 streaming_upload_manager = StreamingUploadManager(api_token=NOTION_API_TOKEN, socketio=socketio, notion_uploader=uploader)

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -1,0 +1,133 @@
+import time
+from types import SimpleNamespace
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from uploader.streaming_uploader import StreamingUploadManager
+
+
+class ControlledTimer:
+    instances = []
+
+    def __init__(self, interval, function):
+        self.interval = interval
+        self.function = function
+        self.cancelled = False
+        self.daemon = True
+        ControlledTimer.instances.append(self)
+
+    def start(self):
+        return self
+
+    def fire(self):
+        if not self.cancelled:
+            self.function()
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class DummyNotionClient:
+    def __init__(self, record_index_deletes=True):
+        self.deleted_from_user = []
+        self.deleted_from_index = []
+        self.global_file_index_db_id = "index-db" if record_index_deletes else None
+
+    def delete_file_from_user_database(self, part_id):
+        self.deleted_from_user.append(part_id)
+
+    def delete_file_from_index(self, part_id):
+        self.deleted_from_index.append(part_id)
+
+
+def _build_manager(dummy_client: DummyNotionClient) -> StreamingUploadManager:
+    manager = StreamingUploadManager("token", notion_uploader=dummy_client)
+    manager._timer_factory = lambda interval, func: ControlledTimer(interval, func)
+    return manager
+
+
+def test_orphan_cleanup_deletes_parts_after_delay():
+    client = DummyNotionClient()
+    manager = _build_manager(client)
+    ControlledTimer.instances.clear()
+
+    upload_id = "upload-1"
+    manager.active_uploads[upload_id] = {
+        "upload_id": upload_id,
+        "status": "failed",
+        "uploaded_parts": ["part-a", "part-b"],
+        "failed_at": time.time(),
+    }
+
+    manager._schedule_orphan_cleanup(upload_id)
+
+    assert ControlledTimer.instances, "Timer was not scheduled"
+    timer = ControlledTimer.instances[-1]
+    assert timer.interval == manager._orphan_cleanup_delay_seconds
+
+    # Simulate timer firing
+    timer.fire()
+
+    assert client.deleted_from_user == ["part-a", "part-b"]
+    assert client.deleted_from_index == ["part-a", "part-b"]
+    assert manager.active_uploads[upload_id]["uploaded_parts"] == []
+
+
+def test_orphan_cleanup_skipped_when_status_changes():
+    client = DummyNotionClient()
+    manager = _build_manager(client)
+    ControlledTimer.instances.clear()
+
+    upload_id = "upload-2"
+    manager.active_uploads[upload_id] = {
+        "upload_id": upload_id,
+        "status": "failed",
+        "uploaded_parts": ["part-a"],
+        "failed_at": time.time(),
+    }
+
+    manager._schedule_orphan_cleanup(upload_id)
+    timer = ControlledTimer.instances[-1]
+
+    # Status flips to processing before the timer fires (e.g., resumed upload)
+    manager.active_uploads[upload_id]["status"] = "processing"
+    timer.fire()
+
+    assert client.deleted_from_user == []
+    assert manager.active_uploads[upload_id]["uploaded_parts"] == ["part-a"]
+
+
+def test_rescheduling_cancels_previous_timer():
+    client = DummyNotionClient(record_index_deletes=False)
+    manager = _build_manager(client)
+
+    ControlledTimer.instances.clear()
+
+    upload_id = "upload-3"
+    manager.active_uploads[upload_id] = {
+        "upload_id": upload_id,
+        "status": "failed",
+        "uploaded_parts": ["part-a"],
+        "failed_at": time.time(),
+    }
+
+    ControlledTimer.instances.clear()
+
+    manager._schedule_orphan_cleanup(upload_id)
+    first_timer = ControlledTimer.instances[-1]
+
+    manager._schedule_orphan_cleanup(upload_id)
+    second_timer = ControlledTimer.instances[-1]
+
+    assert first_timer.cancelled is True
+    assert second_timer is not first_timer
+
+    second_timer.fire()
+
+    # Only user DB deletes should be recorded when no global index is configured
+    assert client.deleted_from_user == ["part-a"]
+    assert client.deleted_from_index == []
+    assert manager.active_uploads[upload_id]["uploaded_parts"] == []

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -1449,6 +1449,8 @@ class StreamingUploadManager:
         self.upload_lock = threading.Lock()          # Master lock for upload operations
         self.session_locks: Dict[str, threading.Lock] = {}  # Per-session locks
         self.id_tracking_lock = threading.Lock()     # Lock for ID tracking operations
+        self._timer_factory = threading.Timer        # Allows tests to inject deterministic timers
+        self._orphan_cleanup_delay_seconds = 300     # Five minute grace period before deleting orphaned parts
         
         print("🔒 THREAD SAFETY: StreamingUploadManager initialized with enhanced synchronization")
     
@@ -1515,6 +1517,10 @@ class StreamingUploadManager:
             except Exception as e:
                 print(f"🔒 THREAD SAFETY: Processing failed for {upload_id}: {e}")
                 upload_session['status'] = 'failed'
+                try:
+                    self._schedule_orphan_cleanup(upload_id)
+                except Exception as cleanup_error:
+                    print(f"Warning: Failed to schedule orphan cleanup for {upload_id}: {cleanup_error}")
                 raise
             finally:
                 # Clean up completed/failed uploads
@@ -1529,7 +1535,7 @@ class StreamingUploadManager:
                         if session_status == 'completed' and upload_id in self.session_locks:
                             del self.session_locks[upload_id]
                             print(f"🔒 THREAD SAFETY: Cleaned up session lock for {upload_id}")
-    
+
     def get_upload_status(self, upload_id: str) -> Optional[Dict[str, Any]]:
         """
         Get the status of an upload session
@@ -1551,7 +1557,105 @@ class StreamingUploadManager:
 
         resume_from = status.get('bytes_uploaded', 0)
         return self.process_upload_stream(upload_id, stream_generator, resume_from=resume_from)
-    
+
+    def _schedule_orphan_cleanup(self, upload_id: str, delay_seconds: Optional[int] = None) -> None:
+        """Schedule deletion of orphaned parts for failed or aborted uploads."""
+
+        delay = self._orphan_cleanup_delay_seconds if delay_seconds is None else delay_seconds
+
+        with self.upload_lock:
+            session = self.active_uploads.get(upload_id)
+            if not session:
+                return
+
+            status = session.get('status')
+            uploaded_parts: List[str] = session.get('uploaded_parts', []) or []
+
+            if status not in {'failed', 'aborted'}:
+                return
+
+            if not uploaded_parts:
+                return
+
+            existing_timer = session.get('_orphan_cleanup_timer')
+            if existing_timer:
+                try:
+                    existing_timer.cancel()
+                except Exception:
+                    pass
+
+        notion_uploader = getattr(self.uploader, 'notion_uploader', None)
+        if notion_uploader is None:
+            return
+
+        def _cleanup_orphans() -> None:
+            try:
+                with self.upload_lock:
+                    current_session = self.active_uploads.get(upload_id)
+                    if not current_session:
+                        return
+
+                    current_status = current_session.get('status')
+                    parts_to_delete = list(current_session.get('uploaded_parts', []) or [])
+                    current_session.pop('_orphan_cleanup_timer', None)
+
+                if current_status not in {'failed', 'aborted'}:
+                    return
+
+                if not parts_to_delete:
+                    return
+
+                failed_parts: List[str] = []
+
+                for part_id in parts_to_delete:
+                    try:
+                        notion_uploader.delete_file_from_user_database(part_id)
+                        if getattr(notion_uploader, 'global_file_index_db_id', None):
+                            notion_uploader.delete_file_from_index(part_id)
+                        print(f"Deleted orphan part: {part_id}")
+                    except Exception as delete_error:
+                        print(f"Error deleting orphan part {part_id}: {delete_error}")
+                        failed_parts.append(part_id)
+
+                with self.upload_lock:
+                    session_after_delete = self.active_uploads.get(upload_id)
+                    if not session_after_delete:
+                        return
+
+                    if failed_parts:
+                        remaining = session_after_delete.get('uploaded_parts', []) or []
+                        remaining.extend(failed_parts)
+                        # Deduplicate while preserving order from ``remaining`` then ``failed_parts``
+                        seen: Set[str] = set()
+                        deduped: List[str] = []
+                        for part in remaining:
+                            if part not in seen:
+                                deduped.append(part)
+                                seen.add(part)
+                        session_after_delete['uploaded_parts'] = deduped
+                    else:
+                        remaining = session_after_delete.get('uploaded_parts', []) or []
+                        session_after_delete['uploaded_parts'] = [
+                            part for part in remaining if part not in parts_to_delete
+                        ]
+                        session_after_delete['orphan_cleanup_completed_at'] = time.time()
+            except Exception as unexpected_error:
+                print(f"Unexpected error during orphan cleanup for {upload_id}: {unexpected_error}")
+
+        timer = self._timer_factory(delay, _cleanup_orphans)
+        try:
+            timer.daemon = True
+        except Exception:
+            pass
+
+        with self.upload_lock:
+            session = self.active_uploads.get(upload_id)
+            if not session or session.get('status') not in {'failed', 'aborted'}:
+                return
+            session['_orphan_cleanup_timer'] = timer
+
+        timer.start()
+
     def cleanup_old_sessions(self, max_age_seconds: int = 3600) -> None:
         """
         Clean up old upload sessions


### PR DESCRIPTION
## Summary
- schedule deferred orphan cleanup when multipart uploads fail and cancel timers during session eviction
- make the periodic cleanup timer daemonized and ensure the uploader exposes a get_user_by_id stub for tests
- add targeted tests that exercise the orphan cleanup scheduling logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e55702211c832faf9fac9aa1be409e