### PR TITLE
Prevent premature cleanup of in-progress uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,9 +60,17 @@ def cleanup_old_sessions():
             try:
                 with manager.upload_lock:
                     expired_uploads = []
+                    terminal_statuses = {'completed', 'failed', 'aborted', 'success'}
+                    protected_statuses = {'processing', 'finalizing'}
+
                     for upload_id, session in list(manager.active_uploads.items()):
                         status = session.get('status')
                         last_activity = session.get('last_activity', session.get('created_at', 0))
+
+                        timeout = 900  # Default 15 minutes for active sessions
+                        delete_parts = (status in terminal_statuses) or (status not in protected_statuses)
+                        part_cleanup_grace = None
+
                         if status == 'completed':
                             last_activity = session.get('completed_at', last_activity)
                             timeout = 60  # 1 minute retention for completed uploads
@@ -72,13 +80,32 @@ def cleanup_old_sessions():
                         elif status == 'aborted':
                             last_activity = session.get('aborted_at', last_activity)
                             timeout = 60
+                        elif status in protected_statuses:
+                            activity_grace = session.get('cleanup_grace_period_seconds', 6 * 3600)
+                            part_cleanup_grace = session.get(
+                                'part_cleanup_grace_period_seconds',
+                                max(activity_grace, 12 * 3600)
+                            )
+                            timeout = max(timeout, part_cleanup_grace)
                         else:
-                            timeout = 900  # 15 minutes for active sessions
+                            custom_grace = session.get('cleanup_grace_period_seconds')
+                            if isinstance(custom_grace, (int, float)) and custom_grace > 0:
+                                timeout = max(timeout, custom_grace)
+                            part_cleanup_grace = session.get('part_cleanup_grace_period_seconds')
 
-                        if current_time - last_activity > timeout:
-                            expired_uploads.append((upload_id, session))
+                        expired = current_time - last_activity > timeout
+                        if not expired:
+                            continue
 
-                    for upload_id, session in expired_uploads:
+                        if not delete_parts:
+                            custom_allow = bool(session.get('allow_part_cleanup'))
+                            if part_cleanup_grace is not None:
+                                delete_parts = current_time - last_activity > part_cleanup_grace
+                            delete_parts = delete_parts or custom_allow
+
+                        expired_uploads.append((upload_id, session, delete_parts))
+
+                    for upload_id, session, delete_parts in expired_uploads:
                         removed_session = manager.active_uploads.pop(upload_id, None)
                         manager.session_locks.pop(upload_id, None)
                         if removed_session:
@@ -91,7 +118,8 @@ def cleanup_old_sessions():
                             expired_sessions.append({
                                 'upload_id': upload_id,
                                 'status': removed_session.get('status'),
-                                'uploaded_parts': list(removed_session.get('uploaded_parts', []))
+                                'uploaded_parts': list(removed_session.get('uploaded_parts', [])),
+                                'delete_parts': delete_parts
                             })
                     streaming_sessions = len(manager.active_uploads)
             except Exception as e:
@@ -103,16 +131,22 @@ def cleanup_old_sessions():
 
         for session in expired_sessions:
             status_label = session.get('status') or 'stalled'
-            for part_id in session.get('uploaded_parts', []):
-                if not notion_uploader:
-                    break
-                try:
-                    notion_uploader.delete_file_from_user_database(part_id)
-                    if getattr(notion_uploader, 'global_file_index_db_id', None):
-                        notion_uploader.delete_file_from_index(part_id)
-                    print(f"Deleted orphan part: {part_id}")
-                except Exception as e:
-                    print(f"Error deleting orphan part {part_id}: {e}")
+            if session.get('delete_parts', True):
+                for part_id in session.get('uploaded_parts', []):
+                    if not notion_uploader:
+                        break
+                    try:
+                        notion_uploader.delete_file_from_user_database(part_id)
+                        if getattr(notion_uploader, 'global_file_index_db_id', None):
+                            notion_uploader.delete_file_from_index(part_id)
+                        print(f"Deleted orphan part: {part_id}")
+                    except Exception as e:
+                        print(f"Error deleting orphan part {part_id}: {e}")
+            else:
+                print(
+                    f"Skipping orphan cleanup for {session.get('upload_id')} "
+                    f"(status: {status_label}) due to active grace period"
+                )
             print(f"Cleaned up {status_label} upload session: {session.get('upload_id')}")
 
         print(f"SESSION_CLEANUP: Active streaming sessions: {streaming_sessions}")

--- a/tests/test_cleanup_grace_period.py
+++ b/tests/test_cleanup_grace_period.py
@@ -1,0 +1,59 @@
+import threading
+import time
+from types import SimpleNamespace
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app as flask_app
+
+
+def test_cleanup_preserves_finalizing_sessions(monkeypatch):
+    class DummyTimer:
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+
+        def start(self):
+            return self
+
+        def cancel(self):
+            return None
+
+    monkeypatch.setattr(flask_app.threading, "Timer", lambda interval, func: DummyTimer(interval, func))
+    monkeypatch.setattr(flask_app, "cleanup_stale_streams", lambda: None)
+
+    delete_calls: list[str] = []
+
+    class TrackingCleaner:
+        global_file_index_db_id = None
+
+        def delete_file_from_user_database(self, part_id):
+            delete_calls.append(part_id)
+
+        def delete_file_from_index(self, part_id):
+            delete_calls.append(f"index:{part_id}")
+
+    now = time.time()
+    session = {
+        "upload_id": "long-upload",
+        "status": "finalizing",
+        "uploaded_parts": ["part-1", "part-2"],
+        "created_at": now - 7200,
+        "last_activity": now - 1800,
+    }
+
+    fake_manager = SimpleNamespace(
+        upload_lock=threading.Lock(),
+        active_uploads={"long-upload": session},
+        session_locks={},
+        uploader=SimpleNamespace(notion_uploader=TrackingCleaner()),
+    )
+
+    monkeypatch.setattr(flask_app, "streaming_upload_manager", fake_manager, raising=False)
+
+    flask_app.cleanup_old_sessions()
+
+    assert "long-upload" in fake_manager.active_uploads
+    assert not delete_calls

--- a/tests/test_streaming_uploader.py
+++ b/tests/test_streaming_uploader.py
@@ -288,6 +288,71 @@ def test_streaming_uploader_waits_for_available_workers(monkeypatch):
     assert active == 0
 
 
+def test_part_completion_refreshes_last_activity(uploader, monkeypatch):
+    uploader_instance, fake = uploader
+
+    streaming_module = importlib.import_module("uploader.streaming_uploader")
+
+    class FakeClock:
+        def __init__(self):
+            self._now = 0.0
+            self._lock = threading.Lock()
+
+        def time(self) -> float:
+            with self._lock:
+                return self._now
+
+        def sleep(self, seconds: float) -> None:
+            with self._lock:
+                self._now += seconds
+
+        def tick(self, seconds: float) -> float:
+            with self._lock:
+                self._now += seconds
+                return self._now
+
+    fake_clock = FakeClock()
+    monkeypatch.setattr(streaming_module.time, "time", fake_clock.time)
+    monkeypatch.setattr(streaming_module.time, "sleep", fake_clock.sleep)
+
+    def slow_worker(self, part_session, chunk_queue, part_size, start_event=None):
+        if start_event is not None:
+            start_event.set()
+        data = b""
+        while True:
+            chunk = chunk_queue.get()
+            if chunk is None:
+                break
+            data += chunk
+        assert len(data) == part_size
+        fake_clock.tick(900)
+        return {
+            "file_upload_id": f"upload-{part_session['filename']}",
+            "file_url": f"https://example.com/{part_session['filename']}",
+        }
+
+    monkeypatch.setattr(
+        NotionStreamingUploader,
+        "_upload_part_worker",
+        slow_worker,
+        raising=False,
+    )
+
+    session = uploader_instance.create_upload_session("bigfile", 8, "db1")
+    initial_activity = session["last_activity"]
+    fake_clock.tick(60)
+
+    def stream_gen():
+        yield b"aaaa"
+        yield b"bbbb"
+
+    result = uploader_instance.process_stream(session, stream_gen())
+
+    assert result["status"] == "finalizing"
+    assert session["last_activity"] >= initial_activity + 1800
+    assert fake_clock.time() - session["last_activity"] < 1
+
+
 def test_load_user_returns_cached_user_on_notion_error(monkeypatch):
     if "app" in sys.modules:
         app_module = sys.modules["app"]

--- a/uploader/streaming_uploader.py
+++ b/uploader/streaming_uploader.py
@@ -932,6 +932,7 @@ class NotionStreamingUploader:
 
                     def make_callback(idx, part_filename, part_size, part_salted_hash, part_salt):
                         def _callback(fut: concurrent.futures.Future) -> None:
+                            completion_time = time.time()
                             try:
                                 upload_result = fut.result()
                                 db_entry = self._store_part_in_database(
@@ -955,10 +956,13 @@ class NotionStreamingUploader:
                                         "file_hash": part_salted_hash,
                                         "size": part_size,
                                     })
+                                    upload_session['last_activity'] = completion_time
                             except Exception as e:
                                 print(f"ERROR: Failed to store part {idx} metadata: {e}")
                                 with callback_errors_lock:
                                     callback_errors.append(e)
+                                with parts_lock:
+                                    upload_session['last_activity'] = completion_time
                             finally:
                                 with callback_state_lock:
                                     callback_state["completed"] += 1


### PR DESCRIPTION
## Summary
- extend `cleanup_old_sessions` so processing/finalizing sessions keep their parts until either a terminal state or a long grace period expires
- update multipart upload callbacks to refresh `last_activity` when each part finishes
- add regression tests that simulate long-running uploads and verify cleanup skips active sessions

## Testing
- pytest tests/test_streaming_uploader.py::test_part_completion_refreshes_last_activity tests/test_cleanup_grace_period.py

------
https://chatgpt.com/codex/tasks/task_e_68e681004d94832fad3aaa2f3135dc58