### PR TITLE
Handle transient multipart validation errors during uploads

### DIFF
--- a/tests/test_notion_uploader.py
+++ b/tests/test_notion_uploader.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+s3_dummy = types.ModuleType("s3_downloader")
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+s3_dummy.download_file = _noop
+s3_dummy.download_file_from_url = _noop
+s3_dummy.stream_file_from_url = _noop
+s3_dummy.stream_file_range_from_url = _noop
+s3_dummy.cleanup_stale_streams = _noop
+sys.modules["uploader.s3_downloader"] = s3_dummy
+sys.modules["s3_downloader"] = s3_dummy
+
+from uploader.notion_uploader import NotionFileUploader
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.text = text
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("No JSON")
+        return self._json
+
+
+def test_send_file_part_retries_invalid_multipart(monkeypatch):
+    uploader = NotionFileUploader(api_token="token")
+
+    calls = []
+
+    responses = [
+        _FakeResponse(
+            status_code=400,
+            text="{\"object\":\"error\",\"status\":400,\"code\":\"validation_error\",\"message\":\"Invalid `multipart/form-data` request\"}"
+        ),
+        _FakeResponse(
+            status_code=200,
+            json_data={"object": "file_upload", "id": "file-part"}
+        ),
+    ]
+
+    def fake_post(url, headers, files, timeout):
+        file_entry = files["file"]
+        assert isinstance(file_entry, tuple)
+        file_obj = file_entry[1]
+        body = file_obj.read()
+        calls.append(body)
+        response = responses.pop(0)
+        if response.status_code != 200:
+            response._json = None
+        return response
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = uploader._send_file_part_with_retry(
+        file_upload_id="upload-id",
+        part_number=1,
+        chunk_data=b"a" * 5,
+        filename="file.txt",
+        content_type="text/plain",
+        bytes_uploaded_so_far=0,
+        total_bytes=5,
+        total_parts=1,
+        session_id="session",
+        max_retries=3,
+    )
+
+    assert result["id"] == "file-part"
+    # Ensure two attempts were made and each attempt received the full payload
+    assert len(calls) == 2
+    assert calls[0] == b"a" * 5
+    assert calls[1] == b"a" * 5

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -1379,30 +1379,45 @@ class NotionFileUploader:
         
         # Log memory snapshot for high part numbers
             
-        # Prepare the multipart/form-data request
-        files = {
-            'file': ('file.txt', chunk_data, 'text/plain'),
-            'part_number': (None, str(part_number))
-        }
-        
         last_exception = None
-        
+
         for attempt in range(retry_config['max_retries']):
             try:
+                # Prepare the multipart/form-data request with a fresh
+                # BytesIO wrapper on every attempt.  When ``requests``
+                # submits multipart data it may consume the provided
+                # file-like object.  Reusing the same object across
+                # retries can therefore result in an empty body being
+                # resent, which Notion rejects with
+                # ``Invalid multipart/form-data`` errors.  Wrapping the
+                # bytes each time guarantees the request body is intact
+                # for every retry regardless of how the previous attempt
+                # ended.
+                file_obj = io.BytesIO(chunk_data)
+                files = {
+                    'file': ('file.txt', file_obj, 'text/plain'),
+                    'part_number': (None, str(part_number))
+                }
+
                 # Log request start
-                
+
                 # Multi-tier timeout strategy: (connect_timeout, read_timeout)
                 timeout_config = (30, 300)  # 30s connect, 5min read
-                
-                response = requests.post(
-                    upload_url,
-                    headers=headers,
-                    files=files,
-                    timeout=timeout_config
-                )
-                
+
+                try:
+                    response = requests.post(
+                        upload_url,
+                        headers=headers,
+                        files=files,
+                        timeout=timeout_config
+                    )
+                finally:
+                    # ``requests`` may keep the BytesIO object open; close it
+                    # explicitly so that retries do not accumulate buffers.
+                    file_obj.close()
+
                 # Log successful request
-                
+
                 # Check for retryable status codes
                 if response.status_code in retry_config['retryable_status_codes']:
                     if attempt < retry_config['max_retries'] - 1:
@@ -1414,9 +1429,28 @@ class NotionFileUploader:
                         raise Exception(f"Part {part_number} failed with {response.status_code} after {retry_config['max_retries']} attempts: {response.text}")
                 
                 if response.status_code != 200:
-                    print(f"ERROR uploading part {part_number}: {response.text}")
-                    raise Exception(f"Failed to upload part {part_number}: {response.text}")
-                    
+                    error_text = response.text
+                    print(f"ERROR uploading part {part_number}: {error_text}")
+
+                    # Notion occasionally responds with a transient 400
+                    # stating that the multipart body is invalid when the
+                    # upstream request was truncated.  Treat this specific
+                    # error as retryable so we can resend the bytes.
+                    if (
+                        response.status_code == 400
+                        and 'invalid `multipart/form-data` request' in error_text.lower()
+                        and attempt < retry_config['max_retries'] - 1
+                    ):
+                        delay = self._calculate_retry_delay(attempt, retry_config)
+                        print(
+                            f"Part {part_number} received transient 400, retrying in {delay:.2f}s "
+                            f"(attempt {attempt + 1}/{retry_config['max_retries']})"
+                        )
+                        time.sleep(delay)
+                        continue
+
+                    raise Exception(f"Failed to upload part {part_number}: {error_text}")
+
                 # Parse response
                 try:
                     response_data = response.json()


### PR DESCRIPTION
## Summary
- rebuild multipart payloads on each retry and treat transient 400 validation errors as retryable during multipart uploads
- add a regression test covering the multipart retry behaviour

## Testing
- pytest notion-storage/tests/test_notion_uploader.py

------
https://chatgpt.com/codex/tasks/task_e_68e690d72aac832f97407edae6688de6