### PR TITLE
Fix multipart upload payload construction

### DIFF
--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -1379,10 +1379,29 @@ class NotionFileUploader:
         
         # Log memory snapshot for high part numbers
             
-        # Prepare the multipart/form-data request
-        files = {
-            'file': ('file.txt', chunk_data, 'text/plain'),
-            'part_number': (None, str(part_number))
+        # Prepare the multipart/form-data request.
+        #
+        # Using a ``BytesIO`` wrapper prevents ``requests`` from attempting to
+        # reuse an already-consumed stream when a retry occurs.  We also keep
+        # the metadata field separate from the binary file payload to match
+        # standard multipart form expectations from the Notion API.
+
+        # Notion treats the uploaded chunk as binary data regardless of the
+        # original source type, so default to ``application/octet-stream``
+        # unless the caller explicitly provides something else.
+        if content_type and content_type.lower() != 'text/plain':
+            part_content_type = content_type
+        else:
+            part_content_type = 'application/octet-stream'
+
+        def build_multipart_payload() -> Dict[str, Any]:
+            """Create a fresh multipart payload for each attempt."""
+            return {
+                'file': ('file.txt', io.BytesIO(chunk_data), part_content_type),
+            }
+
+        data = {
+            'part_number': str(part_number)
         }
         
         last_exception = None
@@ -1397,7 +1416,8 @@ class NotionFileUploader:
                 response = requests.post(
                     upload_url,
                     headers=headers,
-                    files=files,
+                    files=build_multipart_payload(),
+                    data=data,
                     timeout=timeout_config
                 )
                 


### PR DESCRIPTION
## Summary
- rebuild the multipart payload for each retry using a fresh BytesIO stream
- send the part number as regular form data and default the chunk content type to binary

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68e690d72aac832f97407edae6688de6