### PR TITLE
Trigger file list sync after successful uploads

### DIFF
--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -993,6 +993,7 @@ const uploadFile = async () => {
     try {
         await waitForPendingUploads();
         showStatus('Uploads finalized and ready to view.', 'success');
+        await checkForUpdates();
         if (progressContainer) {
             progressContainer.innerHTML = '';
         }


### PR DESCRIPTION
## Summary
- call `checkForUpdates()` after `waitForPendingUploads()` in the main upload flow so freshly uploaded files appear immediately

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'boto3')*


------
https://chatgpt.com/codex/tasks/task_e_68e7d85d4ee8832f96e77a47a6b034da