### PR TITLE
Retry presigned URL streams after disconnects

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,20 @@
+# Troubleshooting RemoteDisconnected errors
+
+When the uploader streams large files from Notion using a presigned URL, it relies on the `_PresignedStream` helper in `uploader/s3_downloader.py`. This helper wraps a shared `requests` session and yields chunks from `Response.iter_content`. If the remote server closes the socket before sending a complete HTTP response, `requests` raises `RemoteDisconnected` and, after exhausting the retry budget, the error propagates back to the Flask handler (as seen in the stack trace above). 【F:uploader/s3_downloader.py†L133-L205】
+
+In the log snippet, the downloader successfully retrieved metadata and began streaming `The.LEGO.Movie.2014.2160p.UHD.BluRay.REMUX.HDR.HEVC.DTS-HD.MA.5.1-EPSiLON.mkv.part53`, but the origin `dr.makl.xyz` abruptly terminated the TLS connection without replying. Because the client never received an HTTP status line, the standard library raised `RemoteDisconnected("Remote end closed connection without response")`, which `requests` surfaces as a `ConnectionError` after the configured retries are exhausted.
+
+This behavior is typically triggered by one of the following:
+
+- The origin server enforces an idle timeout that is shorter than the time it takes to stream a chunk.
+- Intermediate infrastructure (reverse proxy, CDN, or firewall) kills long-lived connections.
+- The origin process crashes or rejects the request mid-transfer, often visible in accompanying `socket shutdown error: [Errno 9] Bad file descriptor` messages from the socket.io relay.
+
+To mitigate these errors:
+
+1. Verify the upstream server is healthy and capable of serving large ranges without timeouts.
+2. Reduce the configured chunk size or concurrency so each request finishes sooner.
+3. Ensure keep-alive and range requests are supported by the upstream.
+4. If the issue persists, increase `_NUM_DOWNLOAD_ATTEMPTS` or add backoff to accommodate flaky origins.
+
+Because the exception originates from the remote peer rather than our code, the fix usually involves stabilizing the upstream service or adjusting its timeouts.

--- a/tests/test_stream_resume_after_disconnect.py
+++ b/tests/test_stream_resume_after_disconnect.py
@@ -1,0 +1,95 @@
+import io
+import os
+import sys
+import types
+import importlib.util
+
+import requests
+
+
+class _DummyBoto3(types.ModuleType):
+    def client(self, *args, **kwargs):
+        class _C:
+            pass
+
+        return _C()
+
+
+sys.modules.setdefault("boto3", _DummyBoto3("boto3"))
+_transfer_mod = types.ModuleType("boto3.s3.transfer")
+
+
+class _DummyTransfer:
+    def __init__(self, *a, **k):
+        pass
+
+
+_transfer_mod.S3Transfer = _DummyTransfer
+_transfer_mod.TransferConfig = lambda *a, **k: None
+sys.modules.setdefault("boto3.s3.transfer", _transfer_mod)
+
+botocore_mod = types.ModuleType("botocore")
+botocore_mod.UNSIGNED = None
+sys.modules.setdefault("botocore", botocore_mod)
+
+botocore_ex = types.ModuleType("botocore.exceptions")
+botocore_ex.NoCredentialsError = Exception
+sys.modules.setdefault("botocore.exceptions", botocore_ex)
+
+sys.modules.setdefault("botocore.config", types.ModuleType("botocore.config"))
+sys.modules["botocore.config"].Config = lambda *a, **k: None
+
+spec = importlib.util.spec_from_file_location(
+    "s3_downloader",
+    os.path.join(os.path.dirname(__file__), "..", "uploader", "s3_downloader.py"),
+)
+s3 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(s3)
+
+
+class _FailingResponse:
+    def __init__(self, payload: bytes, *, status_code: int = 200, fail_after_first: bool = False):
+        self.status_code = status_code
+        self._payload = payload
+        self._fail_after_first = fail_after_first
+
+    def iter_content(self, chunk_size: int):
+        stream = io.BytesIO(self._payload)
+        while True:
+            chunk = stream.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+            if self._fail_after_first:
+                self._fail_after_first = False
+                raise requests.exceptions.ConnectionError("socket closed")
+
+    def close(self):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+
+def test_stream_resumes_after_disconnect(monkeypatch):
+    data = b"abcdefghij"
+    responses = [
+        _FailingResponse(data, fail_after_first=True),
+        _FailingResponse(data[4:], status_code=206),
+    ]
+    seen_headers = []
+
+    def fake_get(url, headers=None, stream=False):
+        assert responses, "unexpected additional request"
+        seen_headers.append(headers)
+        return responses.pop(0)
+
+    monkeypatch.setattr(s3, "_SESSION", types.SimpleNamespace(get=fake_get))
+    monkeypatch.setattr(s3, "time", types.SimpleNamespace(time=lambda: 0, sleep=lambda _=0: None))
+
+    stream = s3.stream_file_from_url("http://example.com/file", chunk_size=4)
+    collected = b"".join(stream)
+
+    assert collected == data
+    assert seen_headers[0] is None
+    assert seen_headers[1]["Range"] == "bytes=4-"

--- a/uploader/s3_downloader.py
+++ b/uploader/s3_downloader.py
@@ -195,25 +195,52 @@ class _PresignedStream:
         self.close()
 
     def __iter__(self):
+        base_range_start = None
+        base_range_end = None
+        total_emitted = 0
+        if self.headers and "Range" in self.headers:
+            range_spec = self.headers["Range"].split("=", 1)[1]
+            start_str, end_str = range_spec.split("-", 1)
+            base_range_start = int(start_str) if start_str else 0
+            base_range_end = int(end_str) if end_str else None
+
         for attempt in range(_NUM_DOWNLOAD_ATTEMPTS):
-            self._resp = _SESSION.get(self.url, headers=self.headers, stream=True)
+            request_headers = dict(self.headers) if self.headers else {}
+            skip = 0
+            target_bytes = None
+
+            if base_range_start is not None:
+                start = base_range_start + total_emitted
+                end = base_range_end
+                if end is not None and start > end:
+                    return
+                request_headers["Range"] = (
+                    f"bytes={start}-{end}" if end is not None else f"bytes={start}-"
+                )
+                if end is not None:
+                    target_bytes = end - start + 1
+            elif total_emitted:
+                request_headers["Range"] = f"bytes={total_emitted}-"
+
+            self._resp = _SESSION.get(
+                self.url, headers=request_headers or None, stream=True
+            )
             try:
                 if self._resp.status_code not in (200, 206):
                     self._resp.raise_for_status()
 
-                skip = 0
-                target_bytes = None
-                if self.headers and "Range" in self.headers:
-                    range_spec = self.headers["Range"].split("=", 1)[1]
-                    start_str, end_str = range_spec.split("-")
-                    start = int(start_str)
-                    end = int(end_str)
-                    target_bytes = end - start + 1
-                    if self._resp.status_code == 200:
-                        self.close()
-                        raise requests.HTTPError(
-                            "Requested byte range not honored", response=self._resp
-                        )
+                if base_range_start is not None and self._resp.status_code != 206:
+                    self.close()
+                    raise requests.HTTPError(
+                        "Requested byte range not honored", response=self._resp
+                    )
+
+                if (
+                    base_range_start is None
+                    and total_emitted
+                    and self._resp.status_code == 200
+                ):
+                    skip = total_emitted
 
                 bytes_read = 0
                 for chunk in self._resp.iter_content(chunk_size=self.chunk_size):
@@ -230,13 +257,21 @@ class _PresignedStream:
                         to_yield = min(len(chunk), target_bytes - bytes_read)
                         if to_yield <= 0:
                             break
-                        yield chunk[:to_yield]
+                        data = chunk[:to_yield]
+                        yield data
                         bytes_read += to_yield
+                        total_emitted += to_yield
                         if bytes_read >= target_bytes:
                             break
                     else:
                         if chunk:
                             yield chunk
+                            bytes_read += len(chunk)
+                            total_emitted += len(chunk)
+                if target_bytes is not None and bytes_read < target_bytes:
+                    raise requests.exceptions.ConnectionError(
+                        "Stream ended before fulfilling requested range"
+                    )
                 return
             except Exception as e:
                 if attempt == _NUM_DOWNLOAD_ATTEMPTS - 1 or isinstance(e, requests.HTTPError):


### PR DESCRIPTION
## Summary
- resume presigned URL streaming after mid-transfer disconnects by issuing range requests and skipping previously read bytes
- detect truncated range responses and surface them for retry logic instead of returning incomplete data
- add a regression test that simulates a dropped connection and verifies the resumed stream uses byte ranges

## Testing
- pytest tests/test_stream_resume_after_disconnect.py
- pytest tests/test_range_not_honored.py

------
https://chatgpt.com/codex/tasks/task_e_68e803a03708832fb07deef38eaf9fd0