### PR TITLE
Handle date-based expiration properties in Notion integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,53 @@ def _get_prop_text(prop: Dict[str, Any], key: str = 'rich_text', default: Any = 
     values = prop.get(key, [])
     return values[0].get('text', {}).get('content', default) if values else default
 
+
+def _get_prop_datetime(prop: Dict[str, Any], default: str = '') -> str:
+    """Extract a Notion date property, falling back to legacy rich_text."""
+
+    if not isinstance(prop, dict):
+        return default
+
+    date_value = prop.get('date')
+    if isinstance(date_value, dict):
+        start = date_value.get('start')
+        if start is None:
+            return default
+        return start
+
+    return _get_prop_text(prop, default=default)
+
+
+def _normalize_datetime_input(value: str) -> str:
+    """Normalise an ISO-8601 datetime string for storage."""
+
+    if not value:
+        return ''
+
+    normalized = value.strip()
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return normalized
+
+    return dt.isoformat(timespec='seconds')
+
+
+def _parse_notion_datetime(value: str) -> datetime:
+    """Parse a datetime value returned by Notion into a timezone-aware datetime."""
+
+    normalized = value.strip()
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
 # Function to clean up old upload sessions periodically
 def cleanup_old_sessions():
     """Clean up old upload sessions every minute"""
@@ -264,14 +311,13 @@ def _enforce_expirations(user_database_id: str, data: Dict[str, Any]) -> None:
         try:
             props = entry.get('properties', {})
             is_public = props.get('is_public', {}).get('checkbox', False)
-            expires_at = _get_prop_text(props.get('expires_at', {}))
+            expires_at = _get_prop_datetime(props.get('expires_at', {}))
             if not (is_public and expires_at):
                 continue
-            expiry_dt = datetime.fromisoformat(expires_at)
-            if expiry_dt.tzinfo is None:
-                expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
-            else:
-                expiry_dt = expiry_dt.astimezone(timezone.utc)
+            try:
+                expiry_dt = _parse_notion_datetime(expires_at)
+            except ValueError:
+                continue
             if expiry_dt >= now:
                 continue
             file_id = entry.get('id')
@@ -280,7 +326,7 @@ def _enforce_expirations(user_database_id: str, data: Dict[str, Any]) -> None:
             uploader.update_file_public_status(file_id, False, salted_hash)
             uploader.update_file_security_settings(file_id, expires_at='', salted_sha512_hash=salted_hash)
             props['is_public'] = {'checkbox': False}
-            props['expires_at'] = {'rich_text': []}
+            props['expires_at'] = {'date': None}
         except Exception:
             continue
 
@@ -447,7 +493,7 @@ def build_entries(results: List[Dict[str, Any]], current_folder: str) -> List[Di
             is_folder = properties.get('is_folder', {}).get('checkbox', False)
             is_visible = properties.get('is_visible', {}).get('checkbox', True)
             password_hash = _get_prop_text(properties.get('password_hash', {}))
-            expires_at = _get_prop_text(properties.get('expires_at', {}))
+            expires_at = _get_prop_datetime(properties.get('expires_at', {}))
             password_protected = bool(password_hash)
             if name and is_visible and folder_path == current_folder:
                 if is_folder:
@@ -996,15 +1042,15 @@ def download_by_hash(salted_sha512_hash):
         file_props = file_details.get('properties', {})
         display_name = _get_prop_text(file_props.get('filename', {}), 'title', original_filename)
         password_hash = _get_prop_text(file_props.get('password_hash', {}))
-        expires_at = _get_prop_text(file_props.get('expires_at', {}))
+        expires_at = _get_prop_datetime(file_props.get('expires_at', {}))
 
         if expires_at:
             try:
-                expiry_dt = datetime.fromisoformat(expires_at)
-                now = datetime.now(expiry_dt.tzinfo or timezone.utc)
+                expiry_dt = _parse_notion_datetime(expires_at)
+                now = datetime.now(timezone.utc)
                 if expiry_dt < now:
                     return "Link expired", 403
-            except Exception:
+            except ValueError:
                 pass
 
         if password_hash:
@@ -1178,15 +1224,15 @@ def stream_by_hash(salted_sha512_hash):
         file_props = file_details.get('properties', {})
         display_name = _get_prop_text(file_props.get('filename', {}), 'title', original_filename)
         password_hash = _get_prop_text(file_props.get('password_hash', {}))
-        expires_at = _get_prop_text(file_props.get('expires_at', {}))
+        expires_at = _get_prop_datetime(file_props.get('expires_at', {}))
 
         if expires_at:
             try:
-                expiry_dt = datetime.fromisoformat(expires_at)
-                now = datetime.now(expiry_dt.tzinfo or timezone.utc)
+                expiry_dt = _parse_notion_datetime(expires_at)
+                now = datetime.now(timezone.utc)
                 if expiry_dt < now:
                     return "Link expired", 403
-            except Exception:
+            except ValueError:
                 pass
 
         if password_hash:
@@ -1556,7 +1602,7 @@ def get_files_api():
             folder_path = _get_prop_text(file_props.get('folder_path', {}), default='/')
             salt = _get_prop_text(file_props.get('salt', {}), default='')
             password_hash = _get_prop_text(file_props.get('password_hash', {}))
-            expires_at = _get_prop_text(file_props.get('expires_at', {}))
+            expires_at = _get_prop_datetime(file_props.get('expires_at', {}))
 
             password_protected = bool(password_hash)
 
@@ -1652,7 +1698,7 @@ def get_entries_api():
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
                 is_visible = properties.get('is_visible', {}).get('checkbox', True)
                 password_hash = _get_prop_text(properties.get('password_hash', {}))
-                expires_at = _get_prop_text(properties.get('expires_at', {}))
+                expires_at = _get_prop_datetime(properties.get('expires_at', {}))
                 password_protected = bool(password_hash)
 
                 if name and is_visible and folder_path == current_folder:
@@ -1742,7 +1788,7 @@ def search_files_api():
                 is_folder = properties.get('is_folder', {}).get('checkbox', False)
                 is_visible = properties.get('is_visible', {}).get('checkbox', True)
                 password_hash = _get_prop_text(properties.get('password_hash', {}))
-                expires_at = _get_prop_text(properties.get('expires_at', {}))
+                expires_at = _get_prop_datetime(properties.get('expires_at', {}))
                 password_protected = bool(password_hash)
 
                 if not is_visible:
@@ -1948,9 +1994,16 @@ def update_link_settings():
         file_id = data.get('file_id')
         is_public = data.get('is_public')
         password = data.get('password')
-        expires_at = data.get('expires_at')
-        if expires_at is None:
+        raw_expires_at = data.get('expires_at')
+        if raw_expires_at is None:
             expires_at = ''
+        else:
+            expires_at = _normalize_datetime_input(raw_expires_at)
+            if expires_at:
+                try:
+                    _parse_notion_datetime(expires_at)
+                except ValueError:
+                    return jsonify({'error': 'Invalid expires_at format'}), 400
         salted_sha512_hash = data.get('salted_sha512_hash')
 
         if not file_id or is_public is None:
@@ -1963,7 +2016,7 @@ def update_link_settings():
         # Ensure properties exist in the user's database
         uploader.ensure_database_property(user_database_id, 'is_public', 'checkbox')
         uploader.ensure_database_property(user_database_id, 'password_hash', 'rich_text')
-        uploader.ensure_database_property(user_database_id, 'expires_at', 'rich_text')
+        uploader.ensure_database_property(user_database_id, 'expires_at', 'date')
 
         password_hash = None
         if password is not None:

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -1820,6 +1820,21 @@ async function openMoveDialog(fileIds = [], folderIds = []) {
 // =============================================
 let shareTarget = { fileId: null, saltedHash: '' };
 
+function toDateTimeLocalValue(isoString) {
+    if (!isoString) return '';
+    try {
+        const date = new Date(isoString);
+        if (!Number.isNaN(date.getTime())) {
+            const offset = date.getTimezoneOffset();
+            const local = new Date(date.getTime() - offset * 60000);
+            return local.toISOString().slice(0, 16);
+        }
+    } catch (err) {
+        console.warn('Failed to parse expires_at value', err);
+    }
+    return isoString.length >= 16 ? isoString.slice(0, 16) : '';
+}
+
 async function openShareDialog(fileId) {
     shareTarget = { fileId, saltedHash: '' };
     try {
@@ -1838,7 +1853,7 @@ async function openShareDialog(fileId) {
                 password.placeholder = file.password_protected ? '(existing)' : '';
             }
             if (expires) {
-                expires.value = file.expires_at ? file.expires_at.slice(0,16) : '';
+                expires.value = toDateTimeLocalValue(file.expires_at);
             }
         }
     } catch (error) {

--- a/uploader/notion_uploader.py
+++ b/uploader/notion_uploader.py
@@ -222,6 +222,32 @@ class ChunkProcessor:
                 raise
 
 class NotionFileUploader:
+    @staticmethod
+    def _normalize_datetime_string(value: str) -> str:
+        if not value:
+            return ''
+
+        normalized = value.strip()
+        if normalized.endswith('Z'):
+            normalized = normalized[:-1] + '+00:00'
+
+        try:
+            dt = datetime.fromisoformat(normalized)
+        except ValueError:
+            return normalized
+
+        return dt.isoformat(timespec='seconds')
+
+    @staticmethod
+    def _build_date_property(value: Optional[str]) -> Dict[str, Any]:
+        if value:
+            return {"date": {"start": value}}
+        return {"date": None}
+
+    @staticmethod
+    def _build_rich_text_property(value: Optional[str]) -> Dict[str, Any]:
+        return {"rich_text": [{"text": {"content": value}}] if value else []}
+
     def delete_file_from_user_database(self, file_page_id: str) -> Dict[str, Any]:
         """Alias for delete_file_from_db for compatibility with streaming uploader."""
         return self.delete_file_from_db(file_page_id)
@@ -2288,7 +2314,7 @@ class NotionFileUploader:
         # Ensure the is_folder property exists for this database
         self.ensure_database_property(database_id, "is_folder", "checkbox")
         self.ensure_database_property(database_id, "password_hash", "rich_text")
-        self.ensure_database_property(database_id, "expires_at", "rich_text")
+        self.ensure_database_property(database_id, "expires_at", "date")
 
         # CRITICAL FIX 1: Enhanced ID Validation and Logging
         print(f"🔍 ADD_FILE_TO_DB: Starting with file_upload_id: {file_upload_id}")
@@ -2385,10 +2411,10 @@ class NotionFileUploader:
             properties["password_hash"] = {
                 "rich_text": [{"text": {"content": password_hash}}] if password_hash else []
             }
+        normalized_expires_at = None
         if expires_at is not None:
-            properties["expires_at"] = {
-                "rich_text": [{"text": {"content": expires_at}}] if expires_at else []
-            }
+            normalized_expires_at = self._normalize_datetime_string(expires_at)
+            properties["expires_at"] = self._build_date_property(normalized_expires_at)
         # Add is_manifest property if this is a manifest entry
         if is_manifest:
             properties["is_manifest"] = {"checkbox": True}
@@ -2413,6 +2439,17 @@ class NotionFileUploader:
             raise Exception(error_msg)
 
         response = requests.post(url, json=payload, headers=headers)
+
+        if response.status_code == 400 and normalized_expires_at is not None:
+            error_text = response.text or ""
+            if "rich_text" in error_text and "expires_at" in error_text:
+                fallback_properties = dict(properties)
+                fallback_properties["expires_at"] = self._build_rich_text_property(normalized_expires_at)
+                fallback_payload = {
+                    "parent": payload["parent"],
+                    "properties": fallback_properties,
+                }
+                response = requests.post(url, json=fallback_payload, headers=headers)
 
         if response.status_code != 200:
             error_msg = f"Failed to add file to user database: {response.text}"
@@ -2499,7 +2536,7 @@ class NotionFileUploader:
                 file_page = self.get_user_by_id(file_page_id)
                 file_props = file_page.get('properties', {})
                 password_prop = file_props.get('password_hash', {'rich_text': []})
-                expires_prop = file_props.get('expires_at', {'rich_text': []})
+                expires_prop = file_props.get('expires_at', {'date': None})
                 index_entry['properties']['password_hash'] = password_prop
                 index_entry['properties']['expires_at'] = expires_prop
             except Exception as e:
@@ -2622,10 +2659,10 @@ class NotionFileUploader:
             properties["password_hash"] = {
                 "rich_text": [{"text": {"content": password_hash}}] if password_hash else []
             }
+        normalized_expires_at = None
         if expires_at is not None:
-            properties["expires_at"] = {
-                "rich_text": [{"text": {"content": expires_at}}] if expires_at else []
-            }
+            normalized_expires_at = self._normalize_datetime_string(expires_at)
+            properties["expires_at"] = self._build_date_property(normalized_expires_at)
 
         if not properties:
             return {}
@@ -2634,6 +2671,13 @@ class NotionFileUploader:
         headers = {**self.headers, "Content-Type": "application/json"}
 
         response = requests.patch(url, json=payload, headers=headers)
+        if response.status_code == 400 and normalized_expires_at is not None:
+            error_text = response.text or ""
+            if "rich_text" in error_text and "expires_at" in error_text:
+                fallback_properties = dict(properties)
+                fallback_properties["expires_at"] = self._build_rich_text_property(normalized_expires_at)
+                fallback_payload = {"properties": fallback_properties}
+                response = requests.patch(url, json=fallback_payload, headers=headers)
         if response.status_code != 200:
             raise Exception(f"Failed to update file security settings: {response.text}")
 
@@ -2648,7 +2692,7 @@ class NotionFileUploader:
 
         # Ensure security properties exist
         self.ensure_database_property(database_id, "password_hash", "rich_text")
-        self.ensure_database_property(database_id, "expires_at", "rich_text")
+        self.ensure_database_property(database_id, "expires_at", "date")
 
         properties = {
             "filename": {
@@ -2740,7 +2784,7 @@ class NotionFileUploader:
 
         # Ensure security properties exist on the Global File Index
         self.ensure_database_property(global_index_db_id, "Password Hash", "rich_text")
-        self.ensure_database_property(global_index_db_id, "Expires At", "rich_text")
+        self.ensure_database_property(global_index_db_id, "Expires At", "date")
 
         url = f"{self.base_url}/pages"
 
@@ -2766,10 +2810,10 @@ class NotionFileUploader:
             properties["Password Hash"] = {
                 "rich_text": [{"text": {"content": password_hash}}]
             }
+        normalized_expires_at = None
         if expires_at is not None:
-            properties["Expires At"] = {
-                "rich_text": [{"text": {"content": expires_at}}]
-            }
+            normalized_expires_at = self._normalize_datetime_string(expires_at)
+            properties["Expires At"] = self._build_date_property(normalized_expires_at)
 
         payload = {
             "parent": {"database_id": global_index_db_id},
@@ -2780,6 +2824,16 @@ class NotionFileUploader:
 
         try:
             response = requests.post(url, json=payload, headers=headers)
+            if response.status_code == 400 and normalized_expires_at is not None:
+                error_text = response.text or ""
+                if "rich_text" in error_text and "Expires At" in error_text:
+                    fallback_properties = dict(properties)
+                    fallback_properties["Expires At"] = self._build_rich_text_property(normalized_expires_at)
+                    fallback_payload = {
+                        "parent": payload["parent"],
+                        "properties": fallback_properties,
+                    }
+                    response = requests.post(url, json=fallback_payload, headers=headers)
             if response.status_code != 200:
                 raise Exception(f"Failed to add file to Global File Index: {response.text}")
             print(f"✅ Added file to Global Index for {original_filename}")


### PR DESCRIPTION
## Summary
- normalize expiration timestamps and support Notion date properties when reading and enforcing link expirations
- update link settings endpoint and uploader client to send date payloads with a rich_text fallback for legacy databases
- adjust the share dialog to format ISO timestamps for the datetime-local control

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e93a37162c832fbbc5c7b6744e7d8b