### PR TITLE
Add logging for truncated upload streams

### DIFF
--- a/app.py
+++ b/app.py
@@ -2525,6 +2525,16 @@ def stream_file_upload(upload_id):
                         chunk = request.stream.read(chunk_size)
                         if not chunk:
                             print(f"📡 Stream completed, total read: {total_read / 1024 / 1024:.1f}MB")
+                            if expected_size and total_read < expected_size:
+                                missing = expected_size - total_read
+                                print(
+                                    "⚠️ Stream ended before expected size: "
+                                    f"expected {expected_size / 1024 / 1024:.1f}MB, "
+                                    f"received {total_read / 1024 / 1024:.1f}MB "
+                                    f"(missing {missing / 1024 / 1024:.1f}MB). "
+                                    "This usually means the client or a proxy "
+                                    "closed the connection early or enforced an upload limit."
+                                )
                             break
 
                         upload_session['last_activity'] = time.time()


### PR DESCRIPTION
## Summary
- add diagnostic logging when the request stream closes before the expected upload size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea2ceea548832f86e9838524ccc1e1