### PR TITLE
Add Socket.IO job state broadcasts and front-end tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,9 +207,15 @@ def _parse_yt_dlp_progress(line: str) -> Optional[Dict[str, Any]]:
 class YtDlpJobRegistry:
     """Manage yt-dlp background jobs in a thread-safe manner."""
 
-    def __init__(self):
+    def __init__(self, socketio: Optional[SocketIO] = None):
         self._lock = threading.RLock()
         self._jobs: Dict[str, Dict[str, Any]] = {}
+        self._socketio = socketio
+
+    def set_socketio(self, socketio: Optional[SocketIO]) -> None:
+        """Attach a Socket.IO instance for job update broadcasting."""
+
+        self._socketio = socketio
 
     def _job_public_view(self, job: Dict[str, Any]) -> Dict[str, Any]:
         public_job = dict(job)
@@ -218,10 +224,40 @@ class YtDlpJobRegistry:
         public_job.pop('normalized_arguments', None)
         return public_job
 
+    def _derive_terminal_state(self, status: Optional[str]) -> Optional[str]:
+        if not status:
+            return None
+
+        normalized = status.lower()
+        if normalized in {'completed', 'success', 'succeeded'}:
+            return 'success'
+        if normalized in {'failed', 'failure', 'error'}:
+            return 'failure'
+        if normalized in {'cancelled', 'canceled'}:
+            return 'cancelled'
+        return None
+
+    def _emit_job_event(self, event: str, job_snapshot: Dict[str, Any]) -> None:
+        if not self._socketio:
+            return
+        try:
+            payload = {
+                'event': event,
+                'job_id': job_snapshot.get('id'),
+                'job': job_snapshot,
+            }
+            self._socketio.emit('yt_dlp_job_update', payload)
+        except Exception:
+            # Emitting progress updates should never block the job execution path.
+            pass
+
     def create(self, job: Dict[str, Any]) -> Dict[str, Any]:
         with self._lock:
             self._jobs[job['id']] = job
-            return self._job_public_view(job)
+            public_job = self._job_public_view(job)
+
+        self._emit_job_event('created', public_job)
+        return public_job
 
     def list(self) -> List[Dict[str, Any]]:
         with self._lock:
@@ -244,8 +280,13 @@ class YtDlpJobRegistry:
             if not job:
                 return None
             job.update(updates)
+            if 'status' in updates:
+                job['terminal_state'] = self._derive_terminal_state(updates.get('status'))
             job['updated_at'] = _utcnow_isoformat()
-            return self._job_public_view(job)
+            public_job = self._job_public_view(job)
+
+        self._emit_job_event('updated', public_job)
+        return public_job
 
     def update_progress(self, job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         with self._lock:
@@ -255,7 +296,10 @@ class YtDlpJobRegistry:
             progress = job.setdefault('progress', {})
             progress.update({k: v for k, v in updates.items() if v is not None})
             job['updated_at'] = _utcnow_isoformat()
-            return self._job_public_view(job)
+            public_job = self._job_public_view(job)
+
+        self._emit_job_event('progress', public_job)
+        return public_job
 
     def append_log(self, job_id: str, line: str) -> None:
         timestamp = _utcnow_isoformat()
@@ -311,8 +355,13 @@ class YtDlpJobRegistry:
             job.setdefault('logs', []).append({'timestamp': job['completed_at'], 'message': 'Job cancelled by user'})
             progress = job.setdefault('progress', {})
             progress.setdefault('percentage', 0)
+            progress['stage'] = 'cancelled'
             job['error'] = 'Job cancelled by user'
-            return self._job_public_view(job)
+            job['terminal_state'] = 'cancelled'
+            public_job = self._job_public_view(job)
+
+        self._emit_job_event('cancelled', public_job)
+        return public_job
 
 
 yt_dlp_job_registry = YtDlpJobRegistry()
@@ -603,6 +652,8 @@ socketio = SocketIO(
     ping_timeout=60,
     ping_interval=25
 )
+
+yt_dlp_job_registry.set_socketio(socketio)
 
 
 def _detect_worker_count() -> str:
@@ -3198,6 +3249,7 @@ def create_yt_dlp_job():
         },
         'logs': [],
         'error': None,
+        'terminal_state': None,
     }
 
     yt_dlp_job_registry.create(job_record)

--- a/static/upload.js
+++ b/static/upload.js
@@ -999,8 +999,8 @@ const uploadFile = async () => {
 // Remote import workflow helpers
 // ---------------------------------------------------------------------------
 
-const REMOTE_IMPORT_ENDPOINT = '/api/upload/import';
-const REMOTE_IMPORT_STATUS_ENDPOINT = jobId => `/api/upload/import/${encodeURIComponent(jobId)}`;
+const REMOTE_IMPORT_ENDPOINT = '/api/yt-dlp/jobs';
+const REMOTE_IMPORT_STATUS_ENDPOINT = jobId => `/api/yt-dlp/jobs/${encodeURIComponent(jobId)}`;
 const REMOTE_IMPORT_POLL_INTERVAL_MS = 3000;
 
 const remoteImportState = {
@@ -1009,7 +1009,12 @@ const remoteImportState = {
     lastStatus: null,
     lastMessage: null,
     lastProgressText: null,
-    isSubmitting: false
+    lastFilesCompleted: 0,
+    lastStage: null,
+    isSubmitting: false,
+    useSocket: false,
+    socketConnected: false,
+    socketSubscribedJobId: null
 };
 
 function getRemoteImportElements() {
@@ -1133,23 +1138,72 @@ function stopRemoteImportTracking() {
     remoteImportState.lastStatus = null;
     remoteImportState.lastMessage = null;
     remoteImportState.lastProgressText = null;
+    remoteImportState.lastFilesCompleted = 0;
+    remoteImportState.lastStage = null;
+    remoteImportState.useSocket = false;
+    remoteImportState.socketSubscribedJobId = null;
 }
 
-function processRemoteImportUpdate(data) {
-    if (!data) {
+function processRemoteImportUpdate(payload) {
+    if (!payload) {
         return;
     }
 
-    const status = (data.status || '').toString().toLowerCase();
-    const message = data.message || data.detail || data.status_message || '';
-    let progressValue = null;
+    const job = payload.job || payload;
+    if (!job) {
+        return;
+    }
 
-    if (typeof data.progress === 'number') {
-        progressValue = data.progress;
-    } else if (typeof data.percent === 'number') {
-        progressValue = data.percent;
-    } else if (typeof data.percentage === 'number') {
-        progressValue = data.percentage;
+    if (remoteImportState.jobId && job.id && job.id !== remoteImportState.jobId) {
+        return;
+    }
+
+    const progress = job.progress || {};
+    const status = (job.status || '').toString().toLowerCase();
+    const stage = (progress.stage || '').toString().toLowerCase();
+    const terminalState = (job.terminal_state || '').toString().toLowerCase();
+
+    const messageSources = [
+        payload.message,
+        payload.detail,
+        payload.status_message,
+        job.message,
+        job.detail,
+        job.status_message,
+        progress.status_message,
+    ];
+    let combinedMessage = messageSources.find(msg => typeof msg === 'string' && msg.trim().length > 0);
+
+    if (!combinedMessage) {
+        if (stage) {
+            combinedMessage = `Remote import ${stage}`;
+        } else if (status) {
+            combinedMessage = `Remote import ${status}`;
+        } else {
+            combinedMessage = 'Remote import update';
+        }
+    }
+
+    const currentFile = progress.current_file;
+    if (currentFile) {
+        if (stage === 'uploading') {
+            combinedMessage = `Uploading ${currentFile}`;
+        } else if (stage === 'deleting') {
+            combinedMessage = `Finalizing ${currentFile}`;
+        }
+    }
+
+    let progressValue = null;
+    if (typeof progress.percentage === 'number') {
+        progressValue = progress.percentage;
+    } else if (typeof progress.progress === 'number') {
+        progressValue = progress.progress;
+    } else if (typeof payload.progress === 'number') {
+        progressValue = payload.progress;
+    } else if (typeof payload.percent === 'number') {
+        progressValue = payload.percent;
+    } else if (typeof payload.percentage === 'number') {
+        progressValue = payload.percentage;
     }
 
     let progressText = null;
@@ -1162,9 +1216,31 @@ function processRemoteImportUpdate(data) {
         progressText = ` (${percent}% complete)`;
     }
 
-    const combinedMessage = message || (status ? `Remote import ${status}` : 'Remote import update');
-    const terminalSuccess = ['success', 'completed', 'complete', 'done', 'finished'].includes(status);
-    const terminalFailure = ['failed', 'error', 'cancelled', 'canceled', 'rejected'].includes(status);
+    const statusTokens = [status, stage, terminalState].filter(Boolean);
+    const terminalSuccessTokens = new Set(['success', 'completed', 'complete', 'done', 'finished']);
+    const terminalFailureTokens = new Set(['failed', 'failure', 'error', 'cancelled', 'canceled', 'rejected']);
+    const terminalSuccess = statusTokens.some(token => terminalSuccessTokens.has(token));
+    const terminalFailure = statusTokens.some(token => terminalFailureTokens.has(token));
+
+    const filesCompleted = typeof progress.files_completed === 'number' ? progress.files_completed : null;
+    if (filesCompleted !== null) {
+        if (filesCompleted > (remoteImportState.lastFilesCompleted || 0)) {
+            remoteImportState.lastFilesCompleted = filesCompleted;
+            if (typeof loadFiles === 'function') {
+                try {
+                    loadFiles();
+                } catch (err) {
+                    console.warn('loadFiles failed:', err);
+                }
+            }
+        } else if (filesCompleted > remoteImportState.lastFilesCompleted) {
+            remoteImportState.lastFilesCompleted = filesCompleted;
+        }
+    }
+
+    if (stage && stage !== remoteImportState.lastStage) {
+        remoteImportState.lastStage = stage;
+    }
 
     if (terminalSuccess) {
         showStatus(progressText ? `${combinedMessage}${progressText}` : combinedMessage, 'success');
@@ -1181,13 +1257,17 @@ function processRemoteImportUpdate(data) {
     }
 
     if (terminalFailure) {
-        const failureMessage = combinedMessage || 'Remote import failed.';
-        showStatus(failureMessage, 'error');
+        const failureMessage = progressText ? `${combinedMessage}${progressText}` : combinedMessage;
+        showStatus(failureMessage || 'Remote import failed.', 'error');
         stopRemoteImportTracking();
         return;
     }
 
-    if (status !== remoteImportState.lastStatus || combinedMessage !== remoteImportState.lastMessage || progressText !== remoteImportState.lastProgressText) {
+    if (
+        status !== remoteImportState.lastStatus ||
+        combinedMessage !== remoteImportState.lastMessage ||
+        progressText !== remoteImportState.lastProgressText
+    ) {
         showStatus(progressText ? `${combinedMessage}${progressText}` : combinedMessage, 'info');
         remoteImportState.lastStatus = status;
         remoteImportState.lastMessage = combinedMessage;
@@ -1197,6 +1277,9 @@ function processRemoteImportUpdate(data) {
 
 async function pollRemoteImportStatus(jobId) {
     try {
+        if (remoteImportState.useSocket && remoteImportState.socketConnected) {
+            return;
+        }
         const response = await fetch(REMOTE_IMPORT_STATUS_ENDPOINT(jobId), { credentials: 'include' });
         if (response.status === 404) {
             console.warn('Remote import status endpoint returned 404; will retry shortly.');
@@ -1207,7 +1290,7 @@ async function pollRemoteImportStatus(jobId) {
             throw new Error(errorText || `Status request failed with ${response.status}`);
         }
         const data = await response.json();
-        processRemoteImportUpdate(data);
+        processRemoteImportUpdate(data && (data.job || data));
     } catch (error) {
         console.error('Error polling remote import status:', error);
         showStatus(`Unable to retrieve import status: ${error.message}`, 'error');
@@ -1218,15 +1301,73 @@ async function pollRemoteImportStatus(jobId) {
 function startRemoteImportTracking(jobId, initialPayload) {
     stopRemoteImportTracking();
     remoteImportState.jobId = jobId;
+    remoteImportState.lastFilesCompleted = 0;
+    remoteImportState.lastStage = null;
+    remoteImportState.useSocket = remoteImportState.socketConnected;
+    remoteImportState.socketSubscribedJobId = remoteImportState.useSocket ? jobId : null;
 
     if (initialPayload) {
-        processRemoteImportUpdate(initialPayload);
+        processRemoteImportUpdate(initialPayload && (initialPayload.job || initialPayload));
     }
 
-    pollRemoteImportStatus(jobId);
-    remoteImportState.timerId = setInterval(() => {
+    if (!remoteImportState.useSocket) {
         pollRemoteImportStatus(jobId);
-    }, REMOTE_IMPORT_POLL_INTERVAL_MS);
+        remoteImportState.timerId = setInterval(() => {
+            pollRemoteImportStatus(jobId);
+        }, REMOTE_IMPORT_POLL_INTERVAL_MS);
+    }
+}
+
+function handleRemoteImportSocketUpdate(eventPayload) {
+    if (!eventPayload) {
+        return;
+    }
+    const job = eventPayload.job || eventPayload;
+    if (!job || !remoteImportState.jobId) {
+        return;
+    }
+    if (job.id && job.id !== remoteImportState.jobId) {
+        return;
+    }
+
+    if (job.id && remoteImportState.jobId === job.id) {
+        remoteImportState.useSocket = true;
+        remoteImportState.socketSubscribedJobId = job.id;
+    }
+
+    processRemoteImportUpdate(job);
+}
+
+function onRemoteImportSocketConnect() {
+    remoteImportState.socketConnected = true;
+    if (!remoteImportState.jobId) {
+        return;
+    }
+
+    if (remoteImportState.timerId) {
+        clearInterval(remoteImportState.timerId);
+        remoteImportState.timerId = null;
+    }
+
+    remoteImportState.useSocket = true;
+    remoteImportState.socketSubscribedJobId = remoteImportState.jobId;
+}
+
+function onRemoteImportSocketDisconnect() {
+    remoteImportState.socketConnected = false;
+    remoteImportState.socketSubscribedJobId = null;
+
+    if (!remoteImportState.jobId) {
+        return;
+    }
+
+    if (!remoteImportState.timerId) {
+        remoteImportState.useSocket = false;
+        pollRemoteImportStatus(remoteImportState.jobId);
+        remoteImportState.timerId = setInterval(() => {
+            pollRemoteImportStatus(remoteImportState.jobId);
+        }, REMOTE_IMPORT_POLL_INTERVAL_MS);
+    }
 }
 
 async function handleRemoteImportSubmit(event) {
@@ -1259,15 +1400,15 @@ async function handleRemoteImportSubmit(event) {
     }
 
     const payload = {
-        source_url: sourceUrl
+        url: sourceUrl
     };
 
     const resolvedDestination = destinationFolder || (window.currentFolder && window.currentFolder.trim()) || '/';
     if (resolvedDestination) {
-        payload.destination_folder = resolvedDestination;
+        payload.folder_path = resolvedDestination;
     }
     if (advancedCommand) {
-        payload.advanced_command = advancedCommand;
+        payload.command = advancedCommand;
     }
 
     remoteImportState.isSubmitting = true;
@@ -1293,16 +1434,18 @@ async function handleRemoteImportSubmit(event) {
             return;
         }
 
-        const jobId = data && (data.job_id || data.jobId || data.id);
+        const jobPayload = data && (data.job || data);
+        const jobId = jobPayload && (jobPayload.job_id || jobPayload.jobId || jobPayload.id || jobPayload.identifier);
         if (!jobId) {
             showStatus('Import started but no job identifier was returned.', 'error');
             return;
         }
 
-        showStatus(data && data.message ? data.message : 'Import request accepted. Monitoring progress...', 'info');
+        const confirmationMessage = (data && data.message) || (jobPayload && jobPayload.message) || 'Import request accepted. Monitoring progress...';
+        showStatus(confirmationMessage, 'info');
         closeRemoteImportModal();
         resetRemoteImportForm();
-        startRemoteImportTracking(jobId, data);
+        startRemoteImportTracking(jobId, jobPayload);
     } catch (error) {
         console.error('Remote import submission failed:', error);
         showStatus(`Failed to start remote import: ${error.message}`, 'error');
@@ -1354,5 +1497,8 @@ window.__remoteImport = {
     startRemoteImportTracking,
     stopRemoteImportTracking,
     pollRemoteImportStatus,
-    initializeRemoteImportWorkflow
+    initializeRemoteImportWorkflow,
+    handleRemoteImportSocketUpdate,
+    onSocketConnect: onRemoteImportSocketConnect,
+    onSocketDisconnect: onRemoteImportSocketDisconnect
 };

--- a/templates/home.html
+++ b/templates/home.html
@@ -264,7 +264,31 @@
 <script>
     // Initialize socket connection
     const socket = io();
+    window.__appSocket = socket;
     window.currentFolder = "{{ current_folder }}";
+
+    socket.on('connect', () => {
+        if (window.__remoteImport && typeof window.__remoteImport.onSocketConnect === 'function') {
+            window.__remoteImport.onSocketConnect();
+        }
+    });
+
+    socket.on('disconnect', () => {
+        if (window.__remoteImport && typeof window.__remoteImport.onSocketDisconnect === 'function') {
+            window.__remoteImport.onSocketDisconnect();
+        }
+    });
+
+    socket.on('yt_dlp_job_update', (payload) => {
+        if (window.__remoteImport && typeof window.__remoteImport.handleRemoteImportSocketUpdate === 'function') {
+            window.__remoteImport.handleRemoteImportSocketUpdate(payload);
+        }
+    });
+
+    if (socket.connected && window.__remoteImport && typeof window.__remoteImport.onSocketConnect === 'function') {
+        window.__remoteImport.onSocketConnect();
+    }
+
     // Set up event handlers when DOM is fully loaded
     document.addEventListener('DOMContentLoaded', function () {
         // Initialize streaming uploader

--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -168,13 +168,17 @@ def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately):
     job_id = job_data['id']
 
     assert job_data['status'] == 'completed'
+    assert job_data['terminal_state'] == 'success'
     assert job_data['progress']['percentage'] == 100.0
+    assert job_data['progress']['stage'] == 'done'
 
     status_resp = client.get(f'/api/yt-dlp/jobs/{job_id}')
     assert status_resp.status_code == 200
     status_job = status_resp.get_json()['job']
     assert status_job['status'] == 'completed'
+    assert status_job['terminal_state'] == 'success'
     assert status_job['progress']['percentage'] == 100.0
+    assert status_job['progress']['stage'] == 'done'
     assert status_job['progress']['downloaded_bytes'] >= 10 * 1024 * 1024
 
     list_resp = client.get('/api/yt-dlp/jobs')
@@ -201,4 +205,6 @@ def test_cancel_job_marks_cancelled(monkeypatch):
     assert cancel_resp.status_code == 200
     cancelled_job = cancel_resp.get_json()['job']
     assert cancelled_job['status'] == 'cancelled'
+    assert cancelled_job['terminal_state'] == 'cancelled'
     assert cancelled_job['error']
+    assert cancelled_job['progress']['stage'] == 'cancelled'

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -37,6 +37,7 @@ class YtDlpImporter:
 
         if self.upload_manager is None:
             self.job_registry.update(job_id, status='failed', error='Streaming upload manager is not configured')
+            self.job_registry.update_progress(job_id, {'stage': 'failed'})
             return
 
         user_database_id = job_snapshot.get('user_database_id')
@@ -44,6 +45,7 @@ class YtDlpImporter:
 
         if not user_database_id:
             self.job_registry.update(job_id, status='failed', error='User database ID is required to upload files')
+            self.job_registry.update_progress(job_id, {'stage': 'failed'})
             return
 
         if self.ensure_folder_structure:
@@ -51,11 +53,13 @@ class YtDlpImporter:
                 self.ensure_folder_structure(user_database_id, folder_path)
             except Exception as exc:  # pragma: no cover - defensive logging
                 self.job_registry.update(job_id, status='failed', error=str(exc))
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
         normalized_command = job_snapshot.get('normalized_command')
         if not normalized_command:
             self.job_registry.update(job_id, status='failed', error='No command arguments were generated for yt-dlp')
+            self.job_registry.update_progress(job_id, {'stage': 'failed'})
             return
 
         with tempfile.TemporaryDirectory(prefix=f"yt-dlp-{job_id}-") as output_dir:
@@ -64,6 +68,7 @@ class YtDlpImporter:
             executable = command_args[0]
             if shutil.which(executable) is None:
                 self.job_registry.update(job_id, status='failed', error=f"Executable '{executable}' is not available on the server")
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             try:
@@ -77,10 +82,12 @@ class YtDlpImporter:
                 )
             except Exception as exc:
                 self.job_registry.update(job_id, status='failed', error=str(exc))
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             self.job_registry.set_process(job_id, process)
             self.job_registry.update(job_id, status='running', started_at=self._utcnow())
+            self.job_registry.update_progress(job_id, {'stage': 'downloading'})
 
             stop_event = threading.Event()
             process_done_event = threading.Event()
@@ -126,6 +133,7 @@ class YtDlpImporter:
 
             if upload_error.get('error'):
                 self.job_registry.update(job_id, status='failed', error=str(upload_error['error']), completed_at=self._utcnow())
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             final_snapshot = self.job_registry.get_internal(job_id)
@@ -139,11 +147,12 @@ class YtDlpImporter:
                     {
                         'percentage': 100.0,
                         'upload_percentage': 100.0,
-                        'stage': 'completed',
+                        'stage': 'done',
                     },
                 )
             else:
                 self.job_registry.update(job_id, status='failed', error=f'yt-dlp exited with code {exit_code}', completed_at=self._utcnow())
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
 
     # Internal helpers -----------------------------------------------------------
     def _build_command(self, normalized_command: str, output_dir: str) -> Iterable[str]:
@@ -298,6 +307,14 @@ class YtDlpImporter:
             )
         finally:
             try:
+                self.job_registry.update_progress(
+                    job_id,
+                    {
+                        'stage': 'deleting',
+                        'current_file': file_name,
+                        'current_file_index': index,
+                    },
+                )
                 file_path.unlink()
             except FileNotFoundError:
                 pass


### PR DESCRIPTION
## Summary
- emit yt-dlp job lifecycle updates over Socket.IO and record terminal states
- align the importer with explicit stage transitions for download, upload, cleanup, and completion
- update the remote import UI to consume websocket events, refresh listings after each upload, and fall back to REST polling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f3d4ac1ef4832fadf24d7bb8cbb5e2