### PR TITLE
Guard remote URL imports when yt-dlp is unavailable

### DIFF
--- a/app.py
+++ b/app.py
@@ -3273,6 +3273,24 @@ def create_yt_dlp_job():
     except ValueError as exc:
         return jsonify({'error': str(exc)}), 400
 
+    normalized_arguments = normalized.get('normalized_arguments') or []
+    if not normalized_arguments:
+        return jsonify({'error': 'No command arguments were generated for yt-dlp'}), 500
+
+    executable = normalized_arguments[0]
+    if shutil.which(executable) is None:
+        return (
+            jsonify(
+                {
+                    'error': (
+                        f"Executable '{executable}' is not available on the server. "
+                        'Install yt-dlp or adjust PATH before importing from a remote URL.'
+                    )
+                }
+            ),
+            503,
+        )
+
     job_id = payload.get('job_id') or str(uuid.uuid4())
     now_iso = _utcnow_isoformat()
 

--- a/static/upload.js
+++ b/static/upload.js
@@ -1164,9 +1164,11 @@ function processRemoteImportUpdate(payload) {
     const terminalState = (job.terminal_state || '').toString().toLowerCase();
 
     const messageSources = [
+        payload.error,
         payload.message,
         payload.detail,
         payload.status_message,
+        job.error,
         job.message,
         job.detail,
         job.status_message,

--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -130,6 +130,12 @@ def stub_importer_dependencies(monkeypatch):
     yield dummy_manager
 
 
+@pytest.fixture(autouse=True)
+def stub_yt_dlp_binary(monkeypatch):
+    monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
+    yield
+
+
 @pytest.fixture
 def run_jobs_immediately(monkeypatch):
     def submit(func, job_id):
@@ -150,6 +156,21 @@ def test_create_job_requires_url():
     resp = client.post('/api/yt-dlp/jobs', json={})
     assert resp.status_code == 400
     assert 'error' in resp.get_json()
+
+
+def test_create_job_requires_yt_dlp_binary(monkeypatch):
+    client = flask_app.app.test_client()
+    monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: None)
+
+    resp = client.post(
+        '/api/yt-dlp/jobs',
+        json={'url': 'https://example.com/video', 'user_database_id': 'test-db'},
+    )
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload['error'].startswith("Executable 'yt-dlp'")
+    assert flask_app.yt_dlp_job_registry.list() == []
 
 
 def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately):


### PR DESCRIPTION
## Summary
- return a clear error when remote URL imports are attempted without a yt-dlp binary available
- surface job and payload error messages in the remote import progress UI
- add regression coverage for the missing yt-dlp binary path

## Testing
- pytest tests/test_yt_dlp_jobs.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f3f78b66e0832fb79d9e56e996cfe8