### PR TITLE
Ensure yt-dlp output option precedes URL

### DIFF
--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -158,6 +158,19 @@ def test_create_job_requires_url():
     assert 'error' in resp.get_json()
 
 
+def test_build_command_places_output_before_url(tmp_path):
+    importer = importer_module.YtDlpImporter(upload_manager=None, job_registry=None)
+    normalized_command = (
+        "yt-dlp --newline --output %(title)s.%(ext)s --format best https://example.com/video"
+    )
+
+    built = list(importer._build_command(normalized_command, tmp_path.as_posix()))
+
+    assert built[-1] == 'https://example.com/video'
+    assert '--output' in built
+    assert built.index('--output') < len(built) - 1
+
+
 def test_create_job_requires_yt_dlp_binary(monkeypatch):
     client = flask_app.app.test_client()
     monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: None)

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -157,9 +157,20 @@ class YtDlpImporter:
     # Internal helpers -----------------------------------------------------------
     def _build_command(self, normalized_command: str, output_dir: str) -> Iterable[str]:
         parts = shlex.split(normalized_command)
+        if not parts:
+            return []
+
+        # ``_normalize_yt_dlp_inputs`` always appends the target URL as the final
+        # argument.  Preserve that behaviour explicitly so we can safely add our
+        # own ``--output`` argument *before* the URL.  Putting the URL before the
+        # option caused yt-dlp to treat the destination path as a second URL in
+        # some environments, which meant downloads never started.
+        url_token = parts[-1]
+        option_tokens = parts[:-1]
+
         cleaned_parts = []
         skip_next = False
-        for idx, token in enumerate(parts):
+        for token in option_tokens:
             if skip_next:
                 skip_next = False
                 continue
@@ -171,6 +182,7 @@ class YtDlpImporter:
         cleaned_parts.extend([
             '--output',
             os.path.join(output_dir, '%(autonumber+000)3d_%(title)s.%(ext)s'),
+            url_token,
         ])
         return cleaned_parts
 


### PR DESCRIPTION
## Summary
- adjust yt-dlp command building so the generated --output argument is inserted before the download URL, preventing yt-dlp from treating it as another source
- add a regression test covering the expected command ordering

## Testing
- pytest notion-storage/tests/test_yt_dlp_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68f3ff659368832fbda0f4cee9ec5ad2