### PR TITLE
Fix yt-dlp remote import when user database lookup fails

### DIFF
--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -230,6 +230,64 @@ def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately):
     assert any(job['id'] == job_id for job in jobs)
 
 
+def test_job_resolves_missing_user_database_id(monkeypatch, run_jobs_immediately):
+    client = flask_app.app.test_client()
+
+    class DummyProcess:
+        def __init__(self):
+            self.stdout = io.StringIO('[download] 100% of 1.0MiB in 00:01\n')
+
+        def wait(self):
+            return 0
+
+        def poll(self):
+            return None
+
+    class ResolvingUploadManager:
+        def __init__(self):
+            self.created = []
+            self.processed_streams = []
+            self.resolution_calls = []
+
+            def _resolve(user_id):
+                self.resolution_calls.append(user_id)
+                return 'resolved-db'
+
+            self.notion_uploader = SimpleNamespace(get_user_database_id=_resolve)
+
+        def create_upload_session(self, **kwargs):
+            self.created.append(kwargs)
+            return f"upload-{len(self.created)}"
+
+        def process_upload_stream(self, upload_id, stream):
+            data = io.BytesIO()
+            for chunk in stream:
+                data.write(chunk)
+            self.processed_streams.append({'upload_id': upload_id, 'size': data.tell()})
+            return {'upload_id': upload_id, 'status': 'completed'}
+
+    resolving_manager = ResolvingUploadManager()
+    monkeypatch.setattr(flask_app.yt_dlp_importer, 'upload_manager', resolving_manager, raising=False)
+    monkeypatch.setattr(flask_app.uploader, 'get_user_database_id', lambda user_id: None)
+    monkeypatch.setattr(flask_app, 'current_user', SimpleNamespace(id='user-123'))
+    monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
+    monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
+
+    resp = client.post('/api/yt-dlp/jobs', json={'url': 'https://example.com/video'})
+    assert resp.status_code == 201
+
+    job_payload = resp.get_json()['job']
+    job_id = job_payload['id']
+
+    status_resp = client.get(f'/api/yt-dlp/jobs/{job_id}')
+    assert status_resp.status_code == 200
+    status_job = status_resp.get_json()['job']
+
+    assert status_job['status'] == 'completed'
+    assert status_job['user_database_id'] == 'resolved-db'
+    assert status_job['terminal_state'] == 'success'
+    assert resolving_manager.resolution_calls == ['user-123']
+
 def test_cancel_job_marks_cancelled(monkeypatch):
     client = flask_app.app.test_client()
 

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -11,7 +11,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 
 class YtDlpImporter:
@@ -44,9 +44,15 @@ class YtDlpImporter:
         folder_path = (job_snapshot.get('folder_path') or '/').strip() or '/'
 
         if not user_database_id:
-            self.job_registry.update(job_id, status='failed', error='User database ID is required to upload files')
-            self.job_registry.update_progress(job_id, {'stage': 'failed'})
-            return
+            resolved_database_id = self._resolve_user_database_id(job_snapshot.get('requested_by'))
+            if resolved_database_id:
+                user_database_id = resolved_database_id
+                job_snapshot['user_database_id'] = resolved_database_id
+                self.job_registry.update(job_id, user_database_id=resolved_database_id)
+            else:
+                self.job_registry.update(job_id, status='failed', error='User database ID is required to upload files')
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                return
 
         if self.ensure_folder_structure:
             try:
@@ -336,3 +342,42 @@ class YtDlpImporter:
         from datetime import datetime, timezone
 
         return datetime.now(timezone.utc).isoformat()
+
+    def _resolve_user_database_id(self, user_id: Optional[str]) -> Optional[str]:
+        """Best-effort resolution of a user's database ID at execution time."""
+
+        if not user_id:
+            return None
+
+        manager = self.upload_manager
+        if manager is None:
+            return None
+
+        candidates: List[Any] = []
+
+        def _append_candidate(candidate: Any) -> None:
+            if candidate is None:
+                return
+            if any(existing is candidate for existing in candidates):
+                return
+            candidates.append(candidate)
+
+        _append_candidate(getattr(manager, 'notion_uploader', None))
+
+        nested = getattr(manager, 'uploader', None)
+        _append_candidate(nested)
+        if nested is not None:
+            _append_candidate(getattr(nested, 'notion_uploader', None))
+
+        for uploader in candidates:
+            resolver = getattr(uploader, 'get_user_database_id', None)
+            if not callable(resolver):
+                continue
+            try:
+                resolved = resolver(user_id)
+            except Exception:
+                continue
+            if resolved:
+                return resolved
+
+        return None


### PR DESCRIPTION
## Summary
- resolve the user's database ID during yt-dlp execution if the job snapshot is missing it
- update the importer unit tests to cover the runtime resolution behaviour

## Testing
- pytest tests/test_yt_dlp_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68f403d0d3a8832fb449d3a78a65898a