### PR TITLE
Handle yt-dlp jobs that produce no files

### DIFF
--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -4,6 +4,7 @@ import os
 import sys
 import types
 from types import SimpleNamespace
+from pathlib import Path
 
 import pytest
 
@@ -186,7 +187,7 @@ def test_create_job_requires_yt_dlp_binary(monkeypatch):
     assert flask_app.yt_dlp_job_registry.list() == []
 
 
-def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately):
+def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately, tmp_path):
     client = flask_app.app.test_client()
 
     class DummyProcess:
@@ -202,8 +203,24 @@ def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately):
         def poll(self):
             return None
 
+    dispatched = {'value': False}
+
+    def fake_monitor(self, job_id, output_dir, files_queue, stop_event, process_done_event):
+        if not dispatched['value']:
+            target = Path(output_dir) / 'example.bin'
+            target.write_bytes(b'payload')
+            files_queue.put(target)
+            dispatched['value'] = True
+        process_done_event.wait()
+
     monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
     monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
+    monkeypatch.setattr(
+        flask_app.yt_dlp_importer,
+        '_monitor_downloads',
+        types.MethodType(fake_monitor, flask_app.yt_dlp_importer),
+        raising=False,
+    )
 
     resp = client.post('/api/yt-dlp/jobs', json={'url': 'https://example.com/video', 'user_database_id': 'test-db'})
     assert resp.status_code == 201
@@ -243,6 +260,16 @@ def test_job_resolves_missing_user_database_id(monkeypatch, run_jobs_immediately
         def poll(self):
             return None
 
+    dispatched = {'value': False}
+
+    def fake_monitor(self, job_id, output_dir, files_queue, stop_event, process_done_event):
+        if not dispatched['value']:
+            target = Path(output_dir) / 'resolved.bin'
+            target.write_bytes(b'content')
+            files_queue.put(target)
+            dispatched['value'] = True
+        process_done_event.wait()
+
     class ResolvingUploadManager:
         def __init__(self):
             self.created = []
@@ -272,6 +299,12 @@ def test_job_resolves_missing_user_database_id(monkeypatch, run_jobs_immediately
     monkeypatch.setattr(flask_app, 'current_user', SimpleNamespace(id='user-123'))
     monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
     monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
+    monkeypatch.setattr(
+        flask_app.yt_dlp_importer,
+        '_monitor_downloads',
+        types.MethodType(fake_monitor, flask_app.yt_dlp_importer),
+        raising=False,
+    )
 
     resp = client.post('/api/yt-dlp/jobs', json={'url': 'https://example.com/video'})
     assert resp.status_code == 201
@@ -398,3 +431,42 @@ def test_yt_dlp_sequential_file_processing(
     assert fetched_job['status'] == 'completed'
     assert fetched_job['progress']['stage'] == 'done'
     assert fetched_job['progress'].get('files_completed') == len(file_paths)
+
+
+def test_job_fails_when_no_files_downloaded(monkeypatch, run_jobs_immediately, stub_importer_dependencies):
+    client = flask_app.app.test_client()
+
+    class DummyProcess:
+        def __init__(self):
+            self.stdout = io.StringIO('[download] 100% of 1.0MiB in 00:01\n')
+
+        def wait(self):
+            return 0
+
+        def poll(self):
+            return None
+
+    def idle_monitor(self, job_id, output_dir, files_queue, stop_event, process_done_event):
+        process_done_event.wait()
+
+    monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
+    monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
+    monkeypatch.setattr(
+        flask_app.yt_dlp_importer,
+        '_monitor_downloads',
+        types.MethodType(idle_monitor, flask_app.yt_dlp_importer),
+        raising=False,
+    )
+
+    response = client.post(
+        '/api/yt-dlp/jobs',
+        json={'url': 'https://example.com/video', 'user_database_id': 'test-db'},
+    )
+
+    assert response.status_code == 201
+    job_payload = response.get_json()['job']
+
+    assert job_payload['status'] == 'failed'
+    assert job_payload['terminal_state'] == 'failure'
+    assert job_payload['progress']['stage'] == 'failed'
+    assert 'without downloading any files' in (job_payload.get('error') or '').lower()

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -135,7 +135,8 @@ class YtDlpImporter:
             # Signal uploader that discovery is complete
             files_queue.put(None)
             upload_thread.join()
-            self._job_counters.pop(job_id, None)
+            counters = self._job_counters.pop(job_id, {})
+            files_discovered = counters.get('total_files', 0)
 
             if upload_error.get('error'):
                 self.job_registry.update(job_id, status='failed', error=str(upload_error['error']), completed_at=self._utcnow())
@@ -147,6 +148,24 @@ class YtDlpImporter:
                 return
 
             if exit_code == 0:
+                if files_discovered == 0:
+                    failure_message = 'yt-dlp completed without downloading any files.'
+                    self.job_registry.update(
+                        job_id,
+                        status='failed',
+                        error=failure_message,
+                        completed_at=self._utcnow(),
+                    )
+                    self.job_registry.update_progress(
+                        job_id,
+                        {
+                            'stage': 'failed',
+                            'status_message': failure_message,
+                            'files_completed': 0,
+                            'total_files': 0,
+                        },
+                    )
+                    return
                 self.job_registry.update(job_id, status='completed', completed_at=self._utcnow(), error=None)
                 self.job_registry.update_progress(
                     job_id,


### PR DESCRIPTION
## Summary
- mark yt-dlp imports as failed when the downloader finishes without producing any files and surface a descriptive status message
- expand the yt-dlp job tests to simulate file discovery and cover the zero-output case

## Testing
- pytest tests/test_yt_dlp_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68f40be68198832f8478ab61308ea6cc