### PR TITLE
Improve remote import logging and visibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ import re
 import shlex
 import subprocess
 import shutil
+import logging
 from flask_socketio import emit
 from collections import defaultdict
 import gc
@@ -38,6 +39,19 @@ from werkzeug.utils import secure_filename
 from datetime import datetime, timezone
 
 load_dotenv()
+
+
+LOG_LEVEL_NAME = os.getenv('NOTION_STORAGE_LOG_LEVEL', 'INFO').upper()
+LOG_LEVEL = getattr(logging, LOG_LEVEL_NAME, logging.INFO)
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=LOG_LEVEL,
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+    )
+else:
+    logging.getLogger().setLevel(LOG_LEVEL)
+
+logger = logging.getLogger(__name__)
 
 
 def _get_int_env(var_name: str, default: int, minimum: int = 1) -> int:
@@ -310,6 +324,7 @@ class YtDlpJobRegistry:
         self._lock = threading.RLock()
         self._jobs: Dict[str, Dict[str, Any]] = {}
         self._socketio = socketio
+        self._logger = logging.getLogger(f'{__name__}.yt_dlp_registry')
 
     def set_socketio(self, socketio: Optional[SocketIO]) -> None:
         """Attach a Socket.IO instance for job update broadcasting."""
@@ -355,6 +370,13 @@ class YtDlpJobRegistry:
             self._jobs[job['id']] = job
             public_job = self._job_public_view(job)
 
+        self._logger.info(
+            'Registered yt-dlp job %s (status=%s, url=%s, folder=%s)',
+            job.get('id'),
+            job.get('status'),
+            job.get('url'),
+            job.get('folder_path'),
+        )
         self._emit_job_event('created', public_job)
         return public_job
 
@@ -384,6 +406,10 @@ class YtDlpJobRegistry:
             job['updated_at'] = _utcnow_isoformat()
             public_job = self._job_public_view(job)
 
+        if 'status' in updates:
+            self._logger.info('Job %s status updated to %s', job_id, updates.get('status'))
+        else:
+            self._logger.debug('Job %s updated with %s', job_id, updates)
         self._emit_job_event('updated', public_job)
         return public_job
 
@@ -397,6 +423,7 @@ class YtDlpJobRegistry:
             job['updated_at'] = _utcnow_isoformat()
             public_job = self._job_public_view(job)
 
+        self._logger.debug('Job %s progress update: %s', job_id, updates)
         self._emit_job_event('progress', public_job)
         return public_job
 
@@ -412,6 +439,8 @@ class YtDlpJobRegistry:
             if len(entries) > 200:
                 del entries[:-200]
             job['updated_at'] = timestamp
+
+        self._logger.debug('Job %s log entry: %s', job_id, line)
 
     def set_future(self, job_id: str, future: concurrent.futures.Future) -> None:
         with self._lock:
@@ -459,6 +488,7 @@ class YtDlpJobRegistry:
             job['terminal_state'] = 'cancelled'
             public_job = self._job_public_view(job)
 
+        self._logger.info('Job %s cancelled by user', job_id)
         self._emit_job_event('cancelled', public_job)
         return public_job
 
@@ -700,6 +730,8 @@ def cleanup_old_sessions():
         print(f"Error scheduling session cleanup timer: {timer_error}")
     
 app = Flask(__name__)
+app.logger.setLevel(LOG_LEVEL)
+app.logger.propagate = True
 # Use a safe default for development if SECRET_KEY is not provided
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret-key')
 CORS(app)  # Enable CORS for all routes
@@ -3263,22 +3295,42 @@ def list_yt_dlp_jobs():
     return jsonify({'jobs': yt_dlp_job_registry.list()})
 
 
+def _redact_yt_dlp_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a logging-safe snapshot of an incoming yt-dlp payload."""
+
+    if not isinstance(payload, dict):
+        return {}
+
+    redacted: Dict[str, Any] = {}
+    for key, value in payload.items():
+        if key in {'command', 'advanced_command'} and value:
+            redacted[key] = '<redacted>'
+        else:
+            redacted[key] = value
+    return redacted
+
+
 @app.route('/api/yt-dlp/jobs', methods=['POST'])
 @login_required
 def create_yt_dlp_job():
     payload = request.get_json(silent=True) or {}
+    safe_payload = _redact_yt_dlp_payload(payload)
+    app.logger.info('Received yt-dlp import request: %s', safe_payload)
 
     try:
         normalized = _normalize_yt_dlp_inputs(payload)
     except ValueError as exc:
+        app.logger.warning('Rejected yt-dlp job request: %s | payload=%s', exc, safe_payload)
         return jsonify({'error': str(exc)}), 400
 
     normalized_arguments = normalized.get('normalized_arguments') or []
     if not normalized_arguments:
+        app.logger.error('Failed to build yt-dlp command for payload=%s', safe_payload)
         return jsonify({'error': 'No command arguments were generated for yt-dlp'}), 500
 
     executable = normalized_arguments[0]
     if shutil.which(executable) is None:
+        app.logger.error("yt-dlp executable '%s' not found for payload=%s", executable, safe_payload)
         return (
             jsonify(
                 {
@@ -3335,6 +3387,13 @@ def create_yt_dlp_job():
     }
 
     yt_dlp_job_registry.create(job_record)
+    app.logger.info(
+        'Queued yt-dlp job %s for url=%s destination=%s user=%s',
+        job_id,
+        normalized['url'],
+        folder_path,
+        requested_by,
+    )
     future = yt_dlp_executor.submit(_execute_yt_dlp_job, job_id)
     yt_dlp_job_registry.set_future(job_id, future)
 

--- a/static/style.css
+++ b/static/style.css
@@ -1477,3 +1477,53 @@ tr[data-file-hash] .view-button-container .modal-view-link:hover::before {
 #shareModal .close:hover {
     color: #bb86fc;
 }
+
+#remoteImportActivity {
+    background-color: #1e1e1e;
+    border: 1px solid rgba(3, 218, 198, 0.25);
+}
+
+.remote-import-log {
+    max-height: 220px;
+    overflow-y: auto;
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+    background: rgba(18, 18, 18, 0.85);
+}
+
+.remote-import-log-entry {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid rgba(3, 218, 198, 0.1);
+    color: #e0e0e0;
+}
+
+.remote-import-log-entry:last-child {
+    border-bottom: none;
+}
+
+.remote-import-log-time {
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.8rem;
+    color: #03dac6;
+    min-width: 3.8rem;
+}
+
+.remote-import-log-message {
+    flex: 1;
+    word-break: break-word;
+}
+
+.remote-import-log-entry.remote-import-log-error {
+    color: #ff6f91;
+}
+
+.remote-import-log-entry.remote-import-log-success {
+    color: #9dffb0;
+}
+
+.remote-import-log-entry.remote-import-log-warning {
+    color: #ffc778;
+}

--- a/static/upload.js
+++ b/static/upload.js
@@ -1003,6 +1003,56 @@ const REMOTE_IMPORT_ENDPOINT = '/api/yt-dlp/jobs';
 const REMOTE_IMPORT_STATUS_ENDPOINT = jobId => `/api/yt-dlp/jobs/${encodeURIComponent(jobId)}`;
 const REMOTE_IMPORT_POLL_INTERVAL_MS = 3000;
 
+function getRemoteImportActivityCard() {
+    return document.getElementById('remoteImportActivity');
+}
+
+function getRemoteImportLogContainer() {
+    return document.getElementById('remoteImportLog');
+}
+
+function ensureRemoteImportActivityVisible() {
+    const card = getRemoteImportActivityCard();
+    if (card && card.style.display === 'none') {
+        card.style.display = 'block';
+    }
+}
+
+function appendRemoteImportLog(message, level = 'info') {
+    if (!message) {
+        return;
+    }
+
+    const container = getRemoteImportLogContainer();
+    if (!container) {
+        return;
+    }
+
+    ensureRemoteImportActivityVisible();
+
+    const entry = document.createElement('div');
+    entry.className = `remote-import-log-entry remote-import-log-${level}`;
+
+    const timestamp = document.createElement('span');
+    timestamp.className = 'remote-import-log-time';
+    timestamp.textContent = new Date().toLocaleTimeString();
+    entry.appendChild(timestamp);
+
+    const messageSpan = document.createElement('span');
+    messageSpan.className = 'remote-import-log-message';
+    messageSpan.textContent = message;
+    entry.appendChild(messageSpan);
+
+    container.appendChild(entry);
+    container.setAttribute('data-has-entries', 'true');
+
+    while (container.children.length > 200) {
+        container.removeChild(container.firstChild);
+    }
+
+    container.scrollTop = container.scrollHeight;
+}
+
 const remoteImportState = {
     timerId: null,
     jobId: null,
@@ -1014,7 +1064,9 @@ const remoteImportState = {
     isSubmitting: false,
     useSocket: false,
     socketConnected: false,
-    socketSubscribedJobId: null
+    socketSubscribedJobId: null,
+    lastLoggedMessage: null,
+    lastLoggedProgressText: null
 };
 
 function getRemoteImportElements() {
@@ -1088,6 +1140,7 @@ function applyRemoteImportErrors(errorData) {
 
     if (generalMessages.length > 0) {
         showStatus(generalMessages.join(' '), 'error');
+        appendRemoteImportLog(generalMessages.join(' '), 'error');
     }
 }
 
@@ -1142,6 +1195,8 @@ function stopRemoteImportTracking() {
     remoteImportState.lastStage = null;
     remoteImportState.useSocket = false;
     remoteImportState.socketSubscribedJobId = null;
+    remoteImportState.lastLoggedMessage = null;
+    remoteImportState.lastLoggedProgressText = null;
 }
 
 function processRemoteImportUpdate(payload) {
@@ -1224,6 +1279,19 @@ function processRemoteImportUpdate(payload) {
     const terminalSuccess = statusTokens.some(token => terminalSuccessTokens.has(token));
     const terminalFailure = statusTokens.some(token => terminalFailureTokens.has(token));
 
+    const logLevel = terminalFailure ? 'error' : (terminalSuccess ? 'success' : 'info');
+    const logMessage = progressText ? `${combinedMessage}${progressText}` : combinedMessage;
+    if (
+        logMessage && (
+            logMessage !== remoteImportState.lastLoggedMessage ||
+            progressText !== remoteImportState.lastLoggedProgressText
+        )
+    ) {
+        appendRemoteImportLog(logMessage, logLevel);
+        remoteImportState.lastLoggedMessage = logMessage;
+        remoteImportState.lastLoggedProgressText = progressText;
+    }
+
     const filesCompleted = typeof progress.files_completed === 'number' ? progress.files_completed : null;
     if (filesCompleted !== null) {
         if (filesCompleted > (remoteImportState.lastFilesCompleted || 0)) {
@@ -1296,6 +1364,7 @@ async function pollRemoteImportStatus(jobId) {
     } catch (error) {
         console.error('Error polling remote import status:', error);
         showStatus(`Unable to retrieve import status: ${error.message}`, 'error');
+        appendRemoteImportLog(`Unable to retrieve import status: ${error.message}`, 'error');
         stopRemoteImportTracking();
     }
 }
@@ -1307,6 +1376,7 @@ function startRemoteImportTracking(jobId, initialPayload) {
     remoteImportState.lastStage = null;
     remoteImportState.useSocket = remoteImportState.socketConnected;
     remoteImportState.socketSubscribedJobId = remoteImportState.useSocket ? jobId : null;
+    appendRemoteImportLog(`Monitoring remote import job ${jobId}`, 'info');
 
     if (initialPayload) {
         processRemoteImportUpdate(initialPayload && (initialPayload.job || initialPayload));
@@ -1398,6 +1468,7 @@ async function handleRemoteImportSubmit(event) {
             }
         }
         showStatus('Please provide a source URL to import.', 'error');
+        appendRemoteImportLog('Remote import blocked: a source URL is required.', 'error');
         return;
     }
 
@@ -1416,6 +1487,9 @@ async function handleRemoteImportSubmit(event) {
     remoteImportState.isSubmitting = true;
     toggleRemoteImportFormDisabled(true);
     showStatus('Submitting remote import request...', 'info');
+    appendRemoteImportLog(`Submitting remote import request for ${sourceUrl} → ${resolvedDestination}`, 'info');
+    remoteImportState.lastLoggedMessage = null;
+    remoteImportState.lastLoggedProgressText = null;
 
     try {
         const response = await fetch(REMOTE_IMPORT_ENDPOINT, {
@@ -1440,17 +1514,20 @@ async function handleRemoteImportSubmit(event) {
         const jobId = jobPayload && (jobPayload.job_id || jobPayload.jobId || jobPayload.id || jobPayload.identifier);
         if (!jobId) {
             showStatus('Import started but no job identifier was returned.', 'error');
+            appendRemoteImportLog('Import started but no job identifier was returned.', 'error');
             return;
         }
 
         const confirmationMessage = (data && data.message) || (jobPayload && jobPayload.message) || 'Import request accepted. Monitoring progress...';
         showStatus(confirmationMessage, 'info');
+        appendRemoteImportLog(`${confirmationMessage} Job ID: ${jobId}`, 'info');
         closeRemoteImportModal();
         resetRemoteImportForm();
         startRemoteImportTracking(jobId, jobPayload);
     } catch (error) {
         console.error('Remote import submission failed:', error);
         showStatus(`Failed to start remote import: ${error.message}`, 'error');
+        appendRemoteImportLog(`Failed to start remote import: ${error.message}`, 'error');
     } finally {
         remoteImportState.isSubmitting = false;
         toggleRemoteImportFormDisabled(false);

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,6 +5,14 @@
     <h1><i class="fas fa-cloud-upload-alt mr-2"></i>Upload Files</h1>
     <!-- Message container for notifications (will be filled dynamically) -->
     <div id="messageContainer"></div>
+    <div id="remoteImportActivity" class="card shadow-sm mb-4" style="display: none;">
+        <div class="card-header bg-info text-white">
+            <i class="fas fa-tasks mr-2"></i>Remote Import Activity
+        </div>
+        <div class="card-body p-0">
+            <div id="remoteImportLog" class="remote-import-log"></div>
+        </div>
+    </div>
     <div id="folderNav" class="mb-3">
         <strong>Current Folder:</strong> {{ current_folder }}
         {% if current_folder != '/' %}

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import queue
 import shlex
@@ -13,6 +14,9 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -53,15 +57,29 @@ class YtDlpImporter:
         """Execute a yt-dlp job and stream resulting files to Notion."""
         job_snapshot = self.job_registry.get_internal(job_id)
         if not job_snapshot:
+            logger.warning('Job %s missing from registry; aborting execution', job_id)
             return
 
+        logger.info(
+            'Preparing yt-dlp job %s (url=%s)',
+            job_id,
+            job_snapshot.get('url'),
+        )
+
         if self.upload_manager is None:
+            logger.error('Upload manager not configured; aborting job %s', job_id)
             self.job_registry.update(job_id, status='failed', error='Streaming upload manager is not configured')
             self.job_registry.update_progress(job_id, {'stage': 'failed'})
             return
 
         user_database_id = job_snapshot.get('user_database_id')
         folder_path = (job_snapshot.get('folder_path') or '/').strip() or '/'
+        logger.info(
+            'Starting yt-dlp job %s for destination %s (initial database=%s)',
+            job_id,
+            folder_path,
+            user_database_id,
+        )
 
         if not user_database_id:
             resolved_database_id = self._resolve_user_database_id(job_snapshot.get('requested_by'))
@@ -69,7 +87,9 @@ class YtDlpImporter:
                 user_database_id = resolved_database_id
                 job_snapshot['user_database_id'] = resolved_database_id
                 self.job_registry.update(job_id, user_database_id=resolved_database_id)
+                logger.info('Resolved database %s for job %s', resolved_database_id, job_id)
             else:
+                logger.error('Unable to resolve database for job %s', job_id)
                 self.job_registry.update(job_id, status='failed', error='User database ID is required to upload files')
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
@@ -77,22 +97,29 @@ class YtDlpImporter:
         if self.ensure_folder_structure:
             try:
                 self.ensure_folder_structure(user_database_id, folder_path)
+                logger.debug('Ensured folder structure %s for job %s', folder_path, job_id)
             except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception('Folder structure preparation failed for job %s', job_id)
                 self.job_registry.update(job_id, status='failed', error=str(exc))
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
         normalized_command = job_snapshot.get('normalized_command')
         if not normalized_command:
+            logger.error('No normalized command found for job %s', job_id)
             self.job_registry.update(job_id, status='failed', error='No command arguments were generated for yt-dlp')
             self.job_registry.update_progress(job_id, {'stage': 'failed'})
             return
 
         with tempfile.TemporaryDirectory(prefix=f"yt-dlp-{job_id}-") as output_dir:
             command_args = self._build_command(normalized_command, output_dir)
+            human_command = ' '.join(shlex.quote(part) for part in command_args)
+            logger.info('Executing yt-dlp for job %s: %s', job_id, human_command)
+            self.job_registry.append_log(job_id, f'Executing: {human_command}')
 
             executable = command_args[0]
             if shutil.which(executable) is None:
+                logger.error("Executable '%s' missing for job %s", executable, job_id)
                 self.job_registry.update(job_id, status='failed', error=f"Executable '{executable}' is not available on the server")
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
@@ -107,6 +134,7 @@ class YtDlpImporter:
                     universal_newlines=True,
                 )
             except Exception as exc:
+                logger.exception('Failed to start yt-dlp process for job %s', job_id)
                 self.job_registry.update(job_id, status='failed', error=str(exc))
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
@@ -114,6 +142,7 @@ class YtDlpImporter:
             self.job_registry.set_process(job_id, process)
             self.job_registry.update(job_id, status='running', started_at=self._utcnow())
             self.job_registry.update_progress(job_id, {'stage': 'downloading'})
+            logger.info('yt-dlp process started for job %s (pid=%s)', job_id, getattr(process, 'pid', None))
 
             context = _JobContext(
                 job_id=job_id,
@@ -147,19 +176,24 @@ class YtDlpImporter:
             monitor_thread.join()
             upload_thread.join()
 
+            logger.info('yt-dlp process finished for job %s with exit code %s', job_id, exit_code)
+
             if context.discovery_error:
                 failure_message = f'Failed to prepare downloaded files: {context.discovery_error}'
+                logger.error('Job %s discovery error: %s', job_id, context.discovery_error)
                 self.job_registry.update(job_id, status='failed', error=failure_message, completed_at=self._utcnow())
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             if context.upload_error:
+                logger.error('Job %s upload error: %s', job_id, context.upload_error)
                 self.job_registry.update(job_id, status='failed', error=str(context.upload_error), completed_at=self._utcnow())
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             final_snapshot = self.job_registry.get_internal(job_id)
             if not final_snapshot or final_snapshot.get('status') == 'cancelled':
+                logger.info('Job %s cancelled during execution', job_id)
                 return
 
             files_discovered = context.counters.get('files_discovered', 0)
@@ -167,6 +201,7 @@ class YtDlpImporter:
             if exit_code == 0:
                 if files_discovered == 0:
                     failure_message = 'yt-dlp completed without downloading any files.'
+                    logger.error('Job %s completed without downloads', job_id)
                     self.job_registry.update(
                         job_id,
                         status='failed',
@@ -183,6 +218,8 @@ class YtDlpImporter:
                         },
                     )
                     return
+                logger.info('Job %s completed successfully (%s files)', job_id, files_discovered)
+                self.job_registry.append_log(job_id, f'Completed successfully with {files_discovered} files')
                 self.job_registry.update(job_id, status='completed', completed_at=self._utcnow(), error=None)
                 self.job_registry.update_progress(
                     job_id,
@@ -193,6 +230,8 @@ class YtDlpImporter:
                     },
                 )
             else:
+                logger.error('yt-dlp exited with code %s for job %s', exit_code, job_id)
+                self.job_registry.append_log(job_id, f'yt-dlp exited with code {exit_code}')
                 self.job_registry.update(job_id, status='failed', error=f'yt-dlp exited with code {exit_code}', completed_at=self._utcnow())
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
 
@@ -285,6 +324,11 @@ class YtDlpImporter:
                     processed.add(entry)
                     context.files_queue.put(entry)
                     context.record_discovery()
+                    logger.info('Job %s discovered file %s (%s bytes)', context.job_id, entry.name, size)
+                    try:
+                        self.job_registry.append_log(context.job_id, f'Discovered {entry.name} ({size} bytes)')
+                    except Exception:
+                        pass
                     saw_ready_file = True
 
                 if context.process_done_event.is_set():
@@ -362,6 +406,18 @@ class YtDlpImporter:
             'upload_percentage': 0.0,
         }
         self.job_registry.update_progress(job_id, progress_update)
+        logger.info(
+            'Job %s uploading file #%s %s (%s bytes) to %s',
+            job_id,
+            index,
+            file_name,
+            file_size,
+            folder_path,
+        )
+        try:
+            self.job_registry.append_log(job_id, f'Uploading {file_name} ({file_size} bytes)')
+        except Exception:
+            pass
 
         def stream() -> Iterable[bytes]:
             with file_path.open('rb') as handle:
@@ -394,6 +450,11 @@ class YtDlpImporter:
 
         try:
             self.upload_manager.process_upload_stream(upload_id, stream())
+            logger.info('Job %s uploaded %s', job_id, file_name)
+            try:
+                self.job_registry.append_log(job_id, f'Uploaded {file_name}')
+            except Exception:
+                pass
             self.job_registry.update_progress(
                 job_id,
                 {
@@ -418,6 +479,7 @@ class YtDlpImporter:
                     },
                 )
                 file_path.unlink()
+                logger.debug('Job %s removed temporary file %s', job_id, file_name)
             except FileNotFoundError:
                 pass
 


### PR DESCRIPTION
## Summary
- expose a remote import activity card with a live log on the home page
- extend the JavaScript workflow to append remote import events and errors to the log while improving status polling
- add configurable logging with detailed instrumentation for yt-dlp job creation and execution on the server

## Testing
- pytest *(fails: missing boto3 dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4b66c7734832fb7a818fbf1491730