### PR TITLE
Prevent yt-dlp job logs from exposing full command

### DIFF
--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -115,7 +115,10 @@ class YtDlpImporter:
             command_args = self._build_command(normalized_command, output_dir)
             human_command = ' '.join(shlex.quote(part) for part in command_args)
             logger.info('Executing yt-dlp for job %s: %s', job_id, human_command)
-            self.job_registry.append_log(job_id, f'Executing: {human_command}')
+            self.job_registry.append_log(
+                job_id,
+                'Executing yt-dlp command (arguments hidden for security)',
+            )
 
             executable = command_args[0]
             if shutil.which(executable) is None:


### PR DESCRIPTION
## Summary
- replace the yt-dlp job log entry with a generic message so the raw command is not exposed to API consumers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4c1e0f58c832f94d67e68b3ca9229