### PR TITLE
Prevent remote import modal from reloading the page

### DIFF
--- a/static/upload.js
+++ b/static/upload.js
@@ -1443,7 +1443,9 @@ function onRemoteImportSocketDisconnect() {
 }
 
 async function handleRemoteImportSubmit(event) {
-    event.preventDefault();
+    if (event && typeof event.preventDefault === 'function') {
+        event.preventDefault();
+    }
     if (remoteImportState.isSubmitting) {
         return;
     }
@@ -1542,6 +1544,12 @@ function initializeRemoteImportWorkflow() {
 
     resetRemoteImportForm();
     elements.form.addEventListener('submit', handleRemoteImportSubmit);
+
+    if (elements.submitButton) {
+        elements.submitButton.addEventListener('click', (event) => {
+            handleRemoteImportSubmit(event);
+        });
+    }
 
     const modalElement = document.getElementById('remoteImportModal');
     if (modalElement) {

--- a/templates/home.html
+++ b/templates/home.html
@@ -64,8 +64,8 @@
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
-                <div class="modal-body">
-                    <form id="remoteImportForm" novalidate>
+                <form id="remoteImportForm" novalidate>
+                    <div class="modal-body">
                         <div id="remoteImportFormErrors" class="alert alert-danger d-none" role="alert"></div>
                         <div class="form-group">
                             <label for="remoteSourceUrl">Source URL <span class="text-danger">*</span></label>
@@ -87,12 +87,12 @@
                             <small class="form-text text-muted">Use with caution. Commands are validated by the server.</small>
                             <div class="invalid-feedback"></div>
                         </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" form="remoteImportForm" class="btn btn-primary" id="remoteImportSubmit">Start Import</button>
-                </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="remoteImportSubmit">Start Import</button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap the remote import modal contents in a single form so the submit button no longer triggers a full page reload
- guard the remote import submit handler against missing events and trigger it from the button click to keep the modal in-place

## Testing
- pytest *(fails: missing boto3 dependency in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c3afaa10832fa2f0f03fbdf5e8bb