### PR TITLE
Refactor yt-dlp importer pipeline and fix remote import form

### DIFF
--- a/static/upload.js
+++ b/static/upload.js
@@ -1447,12 +1447,12 @@ async function handleRemoteImportSubmit(event) {
         event.preventDefault();
     }
     if (remoteImportState.isSubmitting) {
-        return;
+        return false;
     }
 
     const elements = getRemoteImportElements();
     if (!elements.form) {
-        return;
+        return false;
     }
 
     resetRemoteImportValidation();
@@ -1471,7 +1471,7 @@ async function handleRemoteImportSubmit(event) {
         }
         showStatus('Please provide a source URL to import.', 'error');
         appendRemoteImportLog('Remote import blocked: a source URL is required.', 'error');
-        return;
+        return false;
     }
 
     const payload = {
@@ -1509,7 +1509,7 @@ async function handleRemoteImportSubmit(event) {
 
         if (!response.ok) {
             applyRemoteImportErrors(data || { message: 'The server rejected the import request.' });
-            return;
+            return false;
         }
 
         const jobPayload = data && (data.job || data);
@@ -1517,7 +1517,7 @@ async function handleRemoteImportSubmit(event) {
         if (!jobId) {
             showStatus('Import started but no job identifier was returned.', 'error');
             appendRemoteImportLog('Import started but no job identifier was returned.', 'error');
-            return;
+            return false;
         }
 
         const confirmationMessage = (data && data.message) || (jobPayload && jobPayload.message) || 'Import request accepted. Monitoring progress...';
@@ -1534,6 +1534,8 @@ async function handleRemoteImportSubmit(event) {
         remoteImportState.isSubmitting = false;
         toggleRemoteImportFormDisabled(false);
     }
+
+    return false;
 }
 
 function initializeRemoteImportWorkflow() {
@@ -1589,3 +1591,5 @@ window.__remoteImport = {
     onSocketConnect: onRemoteImportSocketConnect,
     onSocketDisconnect: onRemoteImportSocketDisconnect
 };
+
+window.handleRemoteImportSubmit = handleRemoteImportSubmit;

--- a/templates/home.html
+++ b/templates/home.html
@@ -64,7 +64,7 @@
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
-                <form id="remoteImportForm" novalidate>
+                <form id="remoteImportForm" novalidate onsubmit="return window.handleRemoteImportSubmit ? window.handleRemoteImportSubmit(event) : false;">
                     <div class="modal-body">
                         <div id="remoteImportFormErrors" class="alert alert-danger d-none" role="alert"></div>
                         <div class="form-group">

--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import io
 import os
 import sys
+import threading
 import types
 from types import SimpleNamespace
 from pathlib import Path
@@ -205,22 +206,36 @@ def test_create_job_runs_and_tracks_progress(monkeypatch, run_jobs_immediately, 
 
     dispatched = {'value': False}
 
-    def fake_monitor(self, context):
-        if not dispatched['value']:
-            target = context.output_dir / 'example.bin'
-            target.write_bytes(b'payload')
-            context.files_queue.put(target)
-            context.record_discovery()
-            dispatched['value'] = True
-        context.process_done_event.wait()
-        context.files_queue.put(None)
+    class FakeObserver:
+        def __init__(self, context):
+            self.context = context
+            self._thread = threading.Thread(target=self._run, daemon=True)
+
+        def start(self):
+            self._thread.start()
+
+        def join(self):
+            self._thread.join()
+
+        def _run(self):
+            if not dispatched['value']:
+                target = self.context.output_dir / 'example.bin'
+                target.write_bytes(b'payload')
+                self.context.files_queue.put(target)
+                self.context.metrics.record_discovery()
+                dispatched['value'] = True
+            self.context.process_completed.wait()
+            self.context.files_queue.put(None)
+
+    def stub_create_observer(self, context):
+        return FakeObserver(context)
 
     monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
     monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
     monkeypatch.setattr(
         flask_app.yt_dlp_importer,
-        '_monitor_downloads',
-        types.MethodType(fake_monitor, flask_app.yt_dlp_importer),
+        '_create_directory_observer',
+        types.MethodType(stub_create_observer, flask_app.yt_dlp_importer),
         raising=False,
     )
 
@@ -264,15 +279,29 @@ def test_job_resolves_missing_user_database_id(monkeypatch, run_jobs_immediately
 
     dispatched = {'value': False}
 
-    def fake_monitor(self, context):
-        if not dispatched['value']:
-            target = context.output_dir / 'resolved.bin'
-            target.write_bytes(b'content')
-            context.files_queue.put(target)
-            context.record_discovery()
-            dispatched['value'] = True
-        context.process_done_event.wait()
-        context.files_queue.put(None)
+    class FakeObserver:
+        def __init__(self, context):
+            self.context = context
+            self._thread = threading.Thread(target=self._run, daemon=True)
+
+        def start(self):
+            self._thread.start()
+
+        def join(self):
+            self._thread.join()
+
+        def _run(self):
+            if not dispatched['value']:
+                target = self.context.output_dir / 'resolved.bin'
+                target.write_bytes(b'content')
+                self.context.files_queue.put(target)
+                self.context.metrics.record_discovery()
+                dispatched['value'] = True
+            self.context.process_completed.wait()
+            self.context.files_queue.put(None)
+
+    def stub_create_observer(self, context):
+        return FakeObserver(context)
 
     class ResolvingUploadManager:
         def __init__(self):
@@ -305,8 +334,8 @@ def test_job_resolves_missing_user_database_id(monkeypatch, run_jobs_immediately
     monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
     monkeypatch.setattr(
         flask_app.yt_dlp_importer,
-        '_monitor_downloads',
-        types.MethodType(fake_monitor, flask_app.yt_dlp_importer),
+        '_create_directory_observer',
+        types.MethodType(stub_create_observer, flask_app.yt_dlp_importer),
         raising=False,
     )
 
@@ -386,17 +415,31 @@ def test_yt_dlp_sequential_file_processing(
 
     monkeypatch.setattr(importer_module.Path, 'unlink', tracking_unlink)
 
-    def fake_monitor(self, context):
-        for path in file_paths:
-            context.files_queue.put(path)
-            context.record_discovery()
-        context.process_done_event.wait()
-        context.files_queue.put(None)
+    class FakeObserver:
+        def __init__(self, context):
+            self.context = context
+            self._thread = threading.Thread(target=self._run, daemon=True)
+
+        def start(self):
+            self._thread.start()
+
+        def join(self):
+            self._thread.join()
+
+        def _run(self):
+            for path in file_paths:
+                self.context.files_queue.put(path)
+                self.context.metrics.record_discovery()
+            self.context.process_completed.wait()
+            self.context.files_queue.put(None)
+
+    def stub_create_observer(self, context):
+        return FakeObserver(context)
 
     monkeypatch.setattr(
         flask_app.yt_dlp_importer,
-        '_monitor_downloads',
-        types.MethodType(fake_monitor, flask_app.yt_dlp_importer),
+        '_create_directory_observer',
+        types.MethodType(stub_create_observer, flask_app.yt_dlp_importer),
         raising=False,
     )
 
@@ -452,16 +495,27 @@ def test_job_fails_when_no_files_downloaded(monkeypatch, run_jobs_immediately, s
         def poll(self):
             return None
 
-    def idle_monitor(self, context):
-        context.process_done_event.wait()
-        context.files_queue.put(None)
+    class IdleObserver:
+        def __init__(self, context):
+            self.context = context
+            self._thread = threading.Thread(target=self._run, daemon=True)
+
+        def start(self):
+            self._thread.start()
+
+        def join(self):
+            self._thread.join()
+
+        def _run(self):
+            self.context.process_completed.wait()
+            self.context.files_queue.put(None)
 
     monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: '/usr/bin/yt-dlp')
     monkeypatch.setattr(flask_app.subprocess, 'Popen', lambda *args, **kwargs: DummyProcess())
     monkeypatch.setattr(
         flask_app.yt_dlp_importer,
-        '_monitor_downloads',
-        types.MethodType(idle_monitor, flask_app.yt_dlp_importer),
+        '_create_directory_observer',
+        types.MethodType(lambda self, context: IdleObserver(context), flask_app.yt_dlp_importer),
         raising=False,
     )
 

--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -1,4 +1,4 @@
-"""Utilities for importing downloads via yt-dlp and streaming them to Notion."""
+"""Orchestrate yt-dlp based remote imports into Notion."""
 
 from __future__ import annotations
 
@@ -13,34 +13,311 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set
-
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
-class _JobContext:
-    """Track state shared between the downloader and uploader threads."""
+class _JobMetrics:
+    """Light-weight counter tracking for a running job."""
+
+    files_discovered: int = 0
+    files_uploaded: int = 0
+
+    def record_discovery(self) -> None:
+        self.files_discovered += 1
+
+    def record_upload(self, index: int) -> None:
+        self.files_uploaded = index
+
+
+@dataclass(slots=True)
+class _PipelineContext:
+    """Shared state between directory observers and upload workers."""
 
     job_id: str
     output_dir: Path
-    files_queue: "queue.Queue[Optional[Path]]"
-    stop_event: threading.Event
-    process_done_event: threading.Event
-    counters: Dict[str, int] = field(default_factory=lambda: {'files_discovered': 0, 'files_uploaded': 0})
-    upload_error: Optional[Exception] = None
-    discovery_error: Optional[Exception] = None
+    files_queue: "queue.Queue[Optional[Path]]" = field(default_factory=queue.Queue)
+    stop_event: threading.Event = field(default_factory=threading.Event)
+    process_completed: threading.Event = field(default_factory=threading.Event)
+    metrics: _JobMetrics = field(default_factory=_JobMetrics)
+    discovery_error: Optional[BaseException] = None
+    upload_error: Optional[BaseException] = None
 
-    def record_discovery(self) -> None:
-        self.counters['files_discovered'] = self.counters.get('files_discovered', 0) + 1
 
-    def record_upload(self, index: int) -> None:
-        self.counters['files_uploaded'] = index
+class _DirectoryObserver(threading.Thread):
+    """Poll a download directory for finished files."""
+
+    def __init__(self, context: _PipelineContext, job_registry) -> None:
+        super().__init__(daemon=True)
+        self._context = context
+        self._job_registry = job_registry
+        self._observed_sizes: Dict[Path, int] = {}
+        self._processed: set[Path] = set()
+        self._sentinel_emitted = False
+
+    def run(self) -> None:  # pragma: no cover - thin wrapper around _poll
+        try:
+            self._poll()
+        finally:
+            if not self._sentinel_emitted:
+                self._context.files_queue.put(None)
+                self._sentinel_emitted = True
+
+    def _poll(self) -> None:
+        context = self._context
+        try:
+            while not context.stop_event.is_set():
+                ready_files = self._scan_directory()
+                if ready_files:
+                    for path in ready_files:
+                        context.files_queue.put(path)
+                        context.metrics.record_discovery()
+                        self._processed.add(path)
+                        try:
+                            size = path.stat().st_size
+                        except FileNotFoundError:
+                            size = 0
+                        logger.info('Job %s discovered file %s (%s bytes)', context.job_id, path.name, size)
+                        try:
+                            self._job_registry.append_log(
+                                context.job_id,
+                                f'Discovered {path.name} ({size} bytes)',
+                            )
+                        except Exception:  # pragma: no cover - logging should never break pipeline
+                            pass
+                    continue
+
+                if context.process_completed.is_set():
+                    if not self._pending_entries_exist():
+                        break
+
+                time.sleep(0.5)
+        except Exception as exc:  # pragma: no cover - surfaced to caller
+            context.discovery_error = exc
+            try:
+                self._job_registry.append_log(context.job_id, f'File discovery error: {exc}')
+            except Exception:
+                pass
+        finally:
+            context.files_queue.put(None)
+            self._sentinel_emitted = True
+
+    def _scan_directory(self) -> List[Path]:
+        context = self._context
+        directory = context.output_dir
+        ready: List[Path] = []
+        try:
+            entries = list(directory.iterdir())
+        except FileNotFoundError:
+            context.stop_event.set()
+            return ready
+
+        for entry in entries:
+            if entry in self._processed:
+                continue
+            if not entry.is_file():
+                continue
+            if entry.name.endswith('.part'):
+                continue
+            part_marker = entry.with_suffix(entry.suffix + '.part')
+            if part_marker.exists():
+                continue
+
+            size = entry.stat().st_size
+            previous_size = self._observed_sizes.get(entry)
+            if previous_size is None or previous_size != size:
+                # Wait for the size to stabilise before queuing the file.
+                self._observed_sizes[entry] = size
+                continue
+
+            ready.append(entry)
+
+        return ready
+
+    def _pending_entries_exist(self) -> bool:
+        context = self._context
+        try:
+            for entry in context.output_dir.iterdir():
+                if entry in self._processed:
+                    continue
+                if not entry.is_file():
+                    continue
+                if entry.name.endswith('.part'):
+                    continue
+                part_marker = entry.with_suffix(entry.suffix + '.part')
+                if part_marker.exists():
+                    continue
+                return True
+        except FileNotFoundError:
+            context.stop_event.set()
+        return False
+
+
+class _UploadWorker(threading.Thread):
+    """Consume discovered files and stream them to Notion."""
+
+    def __init__(
+        self,
+        context: _PipelineContext,
+        upload_manager,
+        job_registry,
+        user_database_id: str,
+        folder_path: str,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._context = context
+        self._upload_manager = upload_manager
+        self._job_registry = job_registry
+        self._user_database_id = user_database_id
+        self._folder_path = folder_path
+
+    def run(self) -> None:
+        context = self._context
+        index = 0
+
+        try:
+            while True:
+                try:
+                    item = context.files_queue.get(timeout=0.5)
+                except queue.Empty:
+                    if context.stop_event.is_set() and context.process_completed.is_set():
+                        break
+                    continue
+
+                if item is None:
+                    context.files_queue.task_done()
+                    break
+
+                index += 1
+                try:
+                    self._upload_file(item, index)
+                    context.metrics.record_upload(index)
+                except Exception as exc:  # pragma: no cover - propagated to main thread
+                    context.upload_error = exc
+                    context.stop_event.set()
+                    try:
+                        self._job_registry.append_log(context.job_id, f'Upload error: {exc}')
+                    except Exception:
+                        pass
+                finally:
+                    context.files_queue.task_done()
+        finally:
+            self._drain_queue()
+
+    def _upload_file(self, file_path: Path, index: int) -> None:
+        file_size = file_path.stat().st_size
+        file_name = file_path.name
+        job_id = self._context.job_id
+
+        self._job_registry.update_progress(
+            job_id,
+            {
+                'stage': 'uploading',
+                'current_file': file_name,
+                'current_file_index': index,
+                'current_file_size': file_size,
+                'upload_percentage': 0.0,
+            },
+        )
+
+        logger.info(
+            'Job %s uploading file #%s %s (%s bytes) to %s',
+            job_id,
+            index,
+            file_name,
+            file_size,
+            self._folder_path,
+        )
+        try:
+            self._job_registry.append_log(job_id, f'Uploading {file_name} ({file_size} bytes)')
+        except Exception:
+            pass
+
+        def stream() -> Iterable[bytes]:
+            with file_path.open('rb') as handle:
+                while True:
+                    chunk = handle.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        def progress_callback(percentage: float, bytes_uploaded: int) -> None:
+            self._job_registry.update_progress(
+                job_id,
+                {
+                    'stage': 'uploading',
+                    'upload_percentage': percentage,
+                    'current_file_uploaded_bytes': bytes_uploaded,
+                    'current_file_size': file_size,
+                    'current_file': file_name,
+                    'current_file_index': index,
+                },
+            )
+
+        upload_id = self._upload_manager.create_upload_session(
+            filename=file_name,
+            file_size=file_size,
+            user_database_id=self._user_database_id,
+            progress_callback=progress_callback,
+            folder_path=self._folder_path,
+        )
+
+        try:
+            self._upload_manager.process_upload_stream(upload_id, stream())
+            logger.info('Job %s uploaded %s', job_id, file_name)
+            try:
+                self._job_registry.append_log(job_id, f'Uploaded {file_name}')
+            except Exception:
+                pass
+            self._job_registry.update_progress(
+                job_id,
+                {
+                    'stage': 'uploading',
+                    'upload_percentage': 100.0,
+                    'current_file_uploaded_bytes': file_size,
+                    'current_file_size': file_size,
+                    'current_file': file_name,
+                    'current_file_index': index,
+                    'files_completed': index,
+                    'total_files': index,
+                },
+            )
+        finally:
+            try:
+                self._job_registry.update_progress(
+                    job_id,
+                    {
+                        'stage': 'deleting',
+                        'current_file': file_name,
+                        'current_file_index': index,
+                    },
+                )
+                file_path.unlink()
+                logger.debug('Job %s removed temporary file %s', job_id, file_name)
+            except FileNotFoundError:
+                pass
+
+    def _drain_queue(self) -> None:
+        context = self._context
+        while not context.files_queue.empty():
+            try:
+                item = context.files_queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                if isinstance(item, Path):
+                    try:
+                        item.unlink()
+                    except FileNotFoundError:
+                        pass
+            finally:
+                context.files_queue.task_done()
 
 
 class YtDlpImporter:
-    """Manage yt-dlp based import jobs with background processing."""
+    """Execute yt-dlp jobs and stream downloads to Notion."""
 
     def __init__(
         self,
@@ -52,53 +329,48 @@ class YtDlpImporter:
         self.job_registry = job_registry
         self.ensure_folder_structure = ensure_folder_structure
 
-    # Public API -----------------------------------------------------------------
+    # ------------------------------------------------------------------ Public
     def execute(self, job_id: str, parse_progress: Callable[[str], Optional[Dict[str, Any]]]) -> None:
-        """Execute a yt-dlp job and stream resulting files to Notion."""
         job_snapshot = self.job_registry.get_internal(job_id)
         if not job_snapshot:
             logger.warning('Job %s missing from registry; aborting execution', job_id)
             return
 
-        logger.info(
-            'Preparing yt-dlp job %s (url=%s)',
-            job_id,
-            job_snapshot.get('url'),
-        )
+        logger.info('Preparing yt-dlp job %s (url=%s)', job_id, job_snapshot.get('url'))
 
         if self.upload_manager is None:
-            logger.error('Upload manager not configured; aborting job %s', job_id)
-            self.job_registry.update(job_id, status='failed', error='Streaming upload manager is not configured')
+            self.job_registry.update(
+                job_id,
+                status='failed',
+                error='Streaming upload manager is not configured',
+            )
             self.job_registry.update_progress(job_id, {'stage': 'failed'})
+            logger.error('Upload manager not configured; aborting job %s', job_id)
             return
 
         user_database_id = job_snapshot.get('user_database_id')
         folder_path = (job_snapshot.get('folder_path') or '/').strip() or '/'
-        logger.info(
-            'Starting yt-dlp job %s for destination %s (initial database=%s)',
-            job_id,
-            folder_path,
-            user_database_id,
-        )
-
         if not user_database_id:
-            resolved_database_id = self._resolve_user_database_id(job_snapshot.get('requested_by'))
-            if resolved_database_id:
-                user_database_id = resolved_database_id
-                job_snapshot['user_database_id'] = resolved_database_id
-                self.job_registry.update(job_id, user_database_id=resolved_database_id)
-                logger.info('Resolved database %s for job %s', resolved_database_id, job_id)
+            resolved = self._resolve_user_database_id(job_snapshot.get('requested_by'))
+            if resolved:
+                user_database_id = resolved
+                job_snapshot['user_database_id'] = resolved
+                self.job_registry.update(job_id, user_database_id=resolved)
+                logger.info('Resolved database %s for job %s', resolved, job_id)
             else:
-                logger.error('Unable to resolve database for job %s', job_id)
-                self.job_registry.update(job_id, status='failed', error='User database ID is required to upload files')
+                self.job_registry.update(
+                    job_id,
+                    status='failed',
+                    error='User database ID is required to upload files',
+                )
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                logger.error('Unable to resolve database for job %s', job_id)
                 return
 
         if self.ensure_folder_structure:
             try:
                 self.ensure_folder_structure(user_database_id, folder_path)
-                logger.debug('Ensured folder structure %s for job %s', folder_path, job_id)
-            except Exception as exc:  # pragma: no cover - defensive logging
+            except Exception as exc:  # pragma: no cover - defensive
                 logger.exception('Folder structure preparation failed for job %s', job_id)
                 self.job_registry.update(job_id, status='failed', error=str(exc))
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
@@ -106,88 +378,87 @@ class YtDlpImporter:
 
         normalized_command = job_snapshot.get('normalized_command')
         if not normalized_command:
-            logger.error('No normalized command found for job %s', job_id)
             self.job_registry.update(job_id, status='failed', error='No command arguments were generated for yt-dlp')
             self.job_registry.update_progress(job_id, {'stage': 'failed'})
+            logger.error('No normalized command found for job %s', job_id)
             return
 
-        with tempfile.TemporaryDirectory(prefix=f"yt-dlp-{job_id}-") as output_dir:
-            command_args = self._build_command(normalized_command, output_dir)
-            human_command = ' '.join(shlex.quote(part) for part in command_args)
-            logger.info('Executing yt-dlp for job %s: %s', job_id, human_command)
-            self.job_registry.append_log(job_id, f'Executing: {human_command}')
-
-            executable = command_args[0]
-            if shutil.which(executable) is None:
-                logger.error("Executable '%s' missing for job %s", executable, job_id)
-                self.job_registry.update(job_id, status='failed', error=f"Executable '{executable}' is not available on the server")
+        with tempfile.TemporaryDirectory(prefix=f"yt-dlp-{job_id}-") as tmpdir:
+            command = list(self._build_command(normalized_command, tmpdir))
+            if not command:
+                self.job_registry.update(job_id, status='failed', error='Unable to construct yt-dlp command')
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                logger.error('Failed to build command for job %s', job_id)
                 return
+
+            executable = command[0]
+            if shutil.which(executable) is None:
+                message = f"Executable '{executable}' is not available on the server"
+                self.job_registry.update(job_id, status='failed', error=message)
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                logger.error('Executable %s missing for job %s', executable, job_id)
+                return
+
+            pretty_command = ' '.join(shlex.quote(token) for token in command)
+            logger.info('Executing yt-dlp for job %s: %s', job_id, pretty_command)
+            self.job_registry.append_log(job_id, f'Executing: {pretty_command}')
 
             try:
                 process = subprocess.Popen(
-                    command_args,
+                    command,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,
                     bufsize=1,
                     universal_newlines=True,
                 )
-            except Exception as exc:
+            except Exception as exc:  # pragma: no cover - process launch failure is rare
                 logger.exception('Failed to start yt-dlp process for job %s', job_id)
                 self.job_registry.update(job_id, status='failed', error=str(exc))
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             self.job_registry.set_process(job_id, process)
-            self.job_registry.update(job_id, status='running', started_at=self._utcnow())
+            self.job_registry.update(
+                job_id,
+                status='running',
+                started_at=self._utcnow(),
+            )
             self.job_registry.update_progress(job_id, {'stage': 'downloading'})
-            logger.info('yt-dlp process started for job %s (pid=%s)', job_id, getattr(process, 'pid', None))
 
-            context = _JobContext(
-                job_id=job_id,
-                output_dir=Path(output_dir),
-                files_queue=queue.Queue(),
-                stop_event=threading.Event(),
-                process_done_event=threading.Event(),
-            )
-
-            monitor_thread = threading.Thread(
-                target=self._monitor_downloads,
-                args=(context,),
-                daemon=True,
-            )
-            upload_thread = threading.Thread(
-                target=self._process_files,
-                args=(context, user_database_id, folder_path),
-                daemon=True,
-            )
-
-            monitor_thread.start()
-            upload_thread.start()
+            context = _PipelineContext(job_id=job_id, output_dir=Path(tmpdir))
+            observer = self._create_directory_observer(context)
+            uploader = self._create_upload_worker(context, user_database_id, folder_path)
+            observer.start()
+            uploader.start()
 
             try:
-                exit_code = self._consume_process_output(process, context.job_id, parse_progress)
+                exit_code = self._consume_process_output(process, job_id, parse_progress)
             finally:
-                context.process_done_event.set()
+                context.process_completed.set()
                 context.stop_event.set()
                 self.job_registry.clear_process(job_id)
 
-            monitor_thread.join()
-            upload_thread.join()
+            observer.join()
+            uploader.join()
 
             logger.info('yt-dlp process finished for job %s with exit code %s', job_id, exit_code)
 
             if context.discovery_error:
-                failure_message = f'Failed to prepare downloaded files: {context.discovery_error}'
+                error_message = f'Failed to prepare downloaded files: {context.discovery_error}'
                 logger.error('Job %s discovery error: %s', job_id, context.discovery_error)
-                self.job_registry.update(job_id, status='failed', error=failure_message, completed_at=self._utcnow())
+                self.job_registry.update(job_id, status='failed', error=error_message, completed_at=self._utcnow())
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
             if context.upload_error:
                 logger.error('Job %s upload error: %s', job_id, context.upload_error)
-                self.job_registry.update(job_id, status='failed', error=str(context.upload_error), completed_at=self._utcnow())
+                self.job_registry.update(
+                    job_id,
+                    status='failed',
+                    error=str(context.upload_error),
+                    completed_at=self._utcnow(),
+                )
                 self.job_registry.update_progress(job_id, {'stage': 'failed'})
                 return
 
@@ -196,60 +467,69 @@ class YtDlpImporter:
                 logger.info('Job %s cancelled during execution', job_id)
                 return
 
-            files_discovered = context.counters.get('files_discovered', 0)
+            if exit_code != 0:
+                message = f'yt-dlp exited with code {exit_code}'
+                logger.error('yt-dlp exited with code %s for job %s', exit_code, job_id)
+                self.job_registry.append_log(job_id, message)
+                self.job_registry.update(job_id, status='failed', error=message, completed_at=self._utcnow())
+                self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                return
 
-            if exit_code == 0:
-                if files_discovered == 0:
-                    failure_message = 'yt-dlp completed without downloading any files.'
-                    logger.error('Job %s completed without downloads', job_id)
-                    self.job_registry.update(
-                        job_id,
-                        status='failed',
-                        error=failure_message,
-                        completed_at=self._utcnow(),
-                    )
-                    self.job_registry.update_progress(
-                        job_id,
-                        {
-                            'stage': 'failed',
-                            'status_message': failure_message,
-                            'files_completed': 0,
-                            'total_files': 0,
-                        },
-                    )
-                    return
-                logger.info('Job %s completed successfully (%s files)', job_id, files_discovered)
-                self.job_registry.append_log(job_id, f'Completed successfully with {files_discovered} files')
-                self.job_registry.update(job_id, status='completed', completed_at=self._utcnow(), error=None)
+            if context.metrics.files_discovered == 0:
+                message = 'yt-dlp completed without downloading any files.'
+                logger.error('Job %s completed without downloads', job_id)
+                self.job_registry.update(job_id, status='failed', error=message, completed_at=self._utcnow())
                 self.job_registry.update_progress(
                     job_id,
                     {
-                        'percentage': 100.0,
-                        'upload_percentage': 100.0,
-                        'stage': 'done',
+                        'stage': 'failed',
+                        'status_message': message,
+                        'files_completed': 0,
+                        'total_files': 0,
                     },
                 )
-            else:
-                logger.error('yt-dlp exited with code %s for job %s', exit_code, job_id)
-                self.job_registry.append_log(job_id, f'yt-dlp exited with code {exit_code}')
-                self.job_registry.update(job_id, status='failed', error=f'yt-dlp exited with code {exit_code}', completed_at=self._utcnow())
-                self.job_registry.update_progress(job_id, {'stage': 'failed'})
+                return
 
-    # Internal helpers -----------------------------------------------------------
-    def _build_command(self, normalized_command: str, output_dir: str) -> Iterable[str]:
-        parts = shlex.split(normalized_command)
-        if not parts:
+            logger.info('Job %s completed successfully (%s files)', job_id, context.metrics.files_discovered)
+            self.job_registry.append_log(
+                job_id,
+                f'Completed successfully with {context.metrics.files_discovered} files',
+            )
+            self.job_registry.update(
+                job_id,
+                status='completed',
+                completed_at=self._utcnow(),
+                error=None,
+            )
+            self.job_registry.update_progress(
+                job_id,
+                {
+                    'percentage': 100.0,
+                    'upload_percentage': 100.0,
+                    'stage': 'done',
+                },
+            )
+
+    # --------------------------------------------------------------- Internals
+    def _create_directory_observer(self, context: _PipelineContext) -> _DirectoryObserver:
+        return _DirectoryObserver(context, self.job_registry)
+
+    def _create_upload_worker(
+        self,
+        context: _PipelineContext,
+        user_database_id: str,
+        folder_path: str,
+    ) -> _UploadWorker:
+        return _UploadWorker(context, self.upload_manager, self.job_registry, user_database_id, folder_path)
+
+    def _build_command(self, normalized_command: str, output_dir: str) -> Sequence[str]:
+        tokens = shlex.split(normalized_command)
+        if not tokens:
             return []
 
-        # ``_normalize_yt_dlp_inputs`` always appends the target URL as the final
-        # argument.  Preserve that behaviour explicitly so we can safely add our
-        # own ``--output`` argument *before* the URL.  Putting the URL before the
-        # option caused yt-dlp to treat the destination path as a second URL in
-        # some environments, which meant downloads never started.
-        url_token = parts[-1]
-        option_tokens = parts[:-1]
-
-        cleaned_parts = []
+        url_token = tokens[-1]
+        option_tokens = tokens[:-1]
+        cleaned: List[str] = []
         skip_next = False
         for token in option_tokens:
             if skip_next:
@@ -258,14 +538,14 @@ class YtDlpImporter:
             if token in {'-o', '--output'}:
                 skip_next = True
                 continue
-            cleaned_parts.append(token)
+            cleaned.append(token)
 
-        cleaned_parts.extend([
+        cleaned.extend([
             '--output',
             os.path.join(output_dir, '%(autonumber+000)3d_%(title)s.%(ext)s'),
             url_token,
         ])
-        return cleaned_parts
+        return cleaned
 
     def _consume_process_output(
         self,
@@ -292,197 +572,6 @@ class YtDlpImporter:
                     pass
         return exit_code
 
-    def _monitor_downloads(self, context: _JobContext) -> None:
-        observed_sizes: Dict[Path, int] = {}
-        processed: Set[Path] = set()
-
-        try:
-            while not context.stop_event.is_set() or not context.process_done_event.is_set():
-                try:
-                    entries = list(context.output_dir.iterdir())
-                except FileNotFoundError:
-                    break
-
-                saw_ready_file = False
-                for entry in entries:
-                    if entry in processed:
-                        continue
-                    if not entry.is_file():
-                        continue
-                    if entry.name.endswith('.part'):
-                        continue
-                    part_marker = entry.with_suffix(entry.suffix + '.part')
-                    if part_marker.exists():
-                        continue
-
-                    size = entry.stat().st_size
-                    previous = observed_sizes.get(entry)
-                    if previous is None or previous != size:
-                        observed_sizes[entry] = size
-                        continue
-
-                    processed.add(entry)
-                    context.files_queue.put(entry)
-                    context.record_discovery()
-                    logger.info('Job %s discovered file %s (%s bytes)', context.job_id, entry.name, size)
-                    try:
-                        self.job_registry.append_log(context.job_id, f'Discovered {entry.name} ({size} bytes)')
-                    except Exception:
-                        pass
-                    saw_ready_file = True
-
-                if context.process_done_event.is_set():
-                    pending = [
-                        entry
-                        for entry in entries
-                        if entry.is_file()
-                        and not entry.name.endswith('.part')
-                        and entry not in processed
-                    ]
-                    if not pending:
-                        break
-
-                if not saw_ready_file:
-                    time.sleep(0.5)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            context.discovery_error = exc
-            try:
-                self.job_registry.append_log(context.job_id, f'File discovery error: {exc}')
-            except Exception:
-                pass
-        finally:
-            context.files_queue.put(None)
-
-    def _process_files(
-        self,
-        context: _JobContext,
-        user_database_id: str,
-        folder_path: str,
-    ) -> None:
-        index = 0
-        try:
-            while True:
-                try:
-                    entry = context.files_queue.get(timeout=0.5)
-                except queue.Empty:
-                    if context.stop_event.is_set() and context.process_done_event.is_set():
-                        break
-                    continue
-
-                if entry is None:
-                    context.files_queue.task_done()
-                    break
-
-                index += 1
-                try:
-                    self._upload_file(context.job_id, entry, user_database_id, folder_path, index)
-                    context.record_upload(index)
-                except Exception as exc:  # pragma: no cover - surfaced to caller
-                    context.upload_error = exc
-                    context.stop_event.set()
-                    try:
-                        self.job_registry.append_log(context.job_id, f'Upload error: {exc}')
-                    except Exception:
-                        pass
-                finally:
-                    context.files_queue.task_done()
-        finally:
-            while not context.files_queue.empty():
-                try:
-                    context.files_queue.get_nowait()
-                    context.files_queue.task_done()
-                except queue.Empty:
-                    break
-
-    def _upload_file(self, job_id: str, file_path: Path, user_database_id: str, folder_path: str, index: int) -> None:
-        file_size = file_path.stat().st_size
-        file_name = file_path.name
-
-        progress_update = {
-            'stage': 'uploading',
-            'current_file': file_name,
-            'current_file_index': index,
-            'current_file_size': file_size,
-            'upload_percentage': 0.0,
-        }
-        self.job_registry.update_progress(job_id, progress_update)
-        logger.info(
-            'Job %s uploading file #%s %s (%s bytes) to %s',
-            job_id,
-            index,
-            file_name,
-            file_size,
-            folder_path,
-        )
-        try:
-            self.job_registry.append_log(job_id, f'Uploading {file_name} ({file_size} bytes)')
-        except Exception:
-            pass
-
-        def stream() -> Iterable[bytes]:
-            with file_path.open('rb') as handle:
-                while True:
-                    chunk = handle.read(1024 * 1024)
-                    if not chunk:
-                        break
-                    yield chunk
-
-        def upload_progress(percentage: float, bytes_uploaded: int) -> None:
-            self.job_registry.update_progress(
-                job_id,
-                {
-                    'stage': 'uploading',
-                    'upload_percentage': percentage,
-                    'current_file_uploaded_bytes': bytes_uploaded,
-                    'current_file_size': file_size,
-                    'current_file': file_name,
-                    'current_file_index': index,
-                },
-            )
-
-        upload_id = self.upload_manager.create_upload_session(
-            filename=file_name,
-            file_size=file_size,
-            user_database_id=user_database_id,
-            progress_callback=upload_progress,
-            folder_path=folder_path,
-        )
-
-        try:
-            self.upload_manager.process_upload_stream(upload_id, stream())
-            logger.info('Job %s uploaded %s', job_id, file_name)
-            try:
-                self.job_registry.append_log(job_id, f'Uploaded {file_name}')
-            except Exception:
-                pass
-            self.job_registry.update_progress(
-                job_id,
-                {
-                    'stage': 'uploading',
-                    'upload_percentage': 100.0,
-                    'current_file_uploaded_bytes': file_size,
-                    'current_file_size': file_size,
-                    'current_file': file_name,
-                    'current_file_index': index,
-                    'files_completed': index,
-                    'total_files': index,
-                },
-            )
-        finally:
-            try:
-                self.job_registry.update_progress(
-                    job_id,
-                    {
-                        'stage': 'deleting',
-                        'current_file': file_name,
-                        'current_file_index': index,
-                    },
-                )
-                file_path.unlink()
-                logger.debug('Job %s removed temporary file %s', job_id, file_name)
-            except FileNotFoundError:
-                pass
-
     @staticmethod
     def _utcnow() -> str:
         from datetime import datetime, timezone
@@ -490,8 +579,6 @@ class YtDlpImporter:
         return datetime.now(timezone.utc).isoformat()
 
     def _resolve_user_database_id(self, user_id: Optional[str]) -> Optional[str]:
-        """Best-effort resolution of a user's database ID at execution time."""
-
         if not user_id:
             return None
 
@@ -501,19 +588,15 @@ class YtDlpImporter:
 
         candidates: List[Any] = []
 
-        def _append_candidate(candidate: Any) -> None:
-            if candidate is None:
-                return
-            if any(existing is candidate for existing in candidates):
-                return
-            candidates.append(candidate)
+        def _append(candidate: Any) -> None:
+            if candidate and candidate not in candidates:
+                candidates.append(candidate)
 
-        _append_candidate(getattr(manager, 'notion_uploader', None))
-
+        _append(getattr(manager, 'notion_uploader', None))
         nested = getattr(manager, 'uploader', None)
-        _append_candidate(nested)
+        _append(nested)
         if nested is not None:
-            _append_candidate(getattr(nested, 'notion_uploader', None))
+            _append(getattr(nested, 'notion_uploader', None))
 
         for uploader in candidates:
             resolver = getattr(uploader, 'get_user_database_id', None)
@@ -525,5 +608,4 @@ class YtDlpImporter:
                 continue
             if resolved:
                 return resolved
-
         return None


### PR DESCRIPTION
## Summary
- rewrite the yt-dlp importer around a new pipeline context, directory observer, and upload worker
- update the remote import modal to keep submissions client-side even before scripts bind
- refresh the yt-dlp job tests to exercise the refactored importer helpers

## Testing
- pytest tests/test_yt_dlp_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68f4c60c2f50832fb81efaa38940208f