### PR TITLE
Ensure directory observer waits for stable files after completion

### DIFF
--- a/uploader/yt_dlp_importer.py
+++ b/uploader/yt_dlp_importer.py
@@ -68,7 +68,10 @@ class _DirectoryObserver(threading.Thread):
     def _poll(self) -> None:
         context = self._context
         try:
-            while not context.stop_event.is_set():
+            while True:
+                if context.stop_event.is_set() and not context.process_completed.is_set():
+                    break
+
                 ready_files = self._scan_directory()
                 if ready_files:
                     for path in ready_files:
@@ -87,11 +90,14 @@ class _DirectoryObserver(threading.Thread):
                             )
                         except Exception:  # pragma: no cover - logging should never break pipeline
                             pass
+
+                    if context.process_completed.is_set() and not self._pending_entries_exist():
+                        break
+
                     continue
 
-                if context.process_completed.is_set():
-                    if not self._pending_entries_exist():
-                        break
+                if context.process_completed.is_set() and not self._pending_entries_exist():
+                    break
 
                 time.sleep(0.5)
         except Exception as exc:  # pragma: no cover - surfaced to caller


### PR DESCRIPTION
## Summary
- allow the directory observer loop to continue running after yt-dlp sets the stop event so it can rescan for stabilised files
- only break immediately when the stop event fires before the download process finishes

## Testing
- pytest tests/test_yt_dlp_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68f5108a1dcc832fb3a27cc54d0bf924