### PR TITLE
Ensure remote import workflow initializes after DOM load

### DIFF
--- a/static/upload.js
+++ b/static/upload.js
@@ -1066,7 +1066,8 @@ const remoteImportState = {
     socketConnected: false,
     socketSubscribedJobId: null,
     lastLoggedMessage: null,
-    lastLoggedProgressText: null
+    lastLoggedProgressText: null,
+    initialized: false
 };
 
 function getRemoteImportElements() {
@@ -1539,10 +1540,16 @@ async function handleRemoteImportSubmit(event) {
 }
 
 function initializeRemoteImportWorkflow() {
+    if (remoteImportState.initialized) {
+        return;
+    }
+
     const elements = getRemoteImportElements();
     if (!elements.form) {
         return;
     }
+
+    remoteImportState.initialized = true;
 
     resetRemoteImportForm();
     elements.form.addEventListener('submit', handleRemoteImportSubmit);
@@ -1579,7 +1586,15 @@ function initializeRemoteImportWorkflow() {
     }
 }
 
-document.addEventListener('DOMContentLoaded', initializeRemoteImportWorkflow);
+function runWhenDocumentReady(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    } else {
+        callback();
+    }
+}
+
+runWhenDocumentReady(initializeRemoteImportWorkflow);
 
 // Expose helpers for debugging/testing
 window.__remoteImport = {

--- a/tests/test_remote_import_initialization.py
+++ b/tests/test_remote_import_initialization.py
@@ -1,0 +1,143 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_remote_import_initializes_when_dom_ready():
+    project_root = Path(__file__).resolve().parents[1]
+    upload_js = project_root / "static" / "upload.js"
+
+    node_script = f"""
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('{upload_js.as_posix()}', 'utf8');
+
+const formListeners = [];
+const buttonListeners = [];
+let resetCalled = false;
+
+function makeInput(initialValue = '') {{
+    return {{
+        value: initialValue,
+        classList: {{
+            add() {{}},
+            remove() {{}}
+        }},
+        parentElement: {{
+            querySelector() {{
+                return {{ textContent: '' }};
+            }}
+        }}
+    }};
+}}
+
+const elements = {{
+    remoteImportForm: {{
+        reset() {{ resetCalled = true; }},
+        addEventListener(type, handler) {{ formListeners.push(type); }}
+    }},
+    remoteImportSubmit: {{
+        disabled: false,
+        addEventListener(type, handler) {{ buttonListeners.push(type); }}
+    }},
+    remoteImportFormErrors: {{
+        classList: {{ add() {{}}, remove() {{}} }},
+        textContent: ''
+    }},
+    remoteImportActivity: {{ style: {{ display: 'none' }} }},
+    remoteImportLog: {{
+        appendChild() {{}},
+        setAttribute() {{}},
+        children: [],
+        removeChild() {{}},
+        scrollTop: 0,
+        scrollHeight: 0
+    }},
+    remoteImportModal: {{
+        classList: {{ remove() {{}} }},
+        setAttribute() {{}},
+        style: {{}},
+        querySelector() {{ return null; }}
+    }},
+    messageContainer: {{
+        innerHTML: '',
+        appendChild() {{}},
+        removeChild() {{}}
+    }}
+}};
+
+const documentStub = {{
+    readyState: 'complete',
+    addEventListener(event, handler) {{
+        // DOMContentLoaded already fired; nothing to do.
+    }},
+    getElementById(id) {{
+        if (id === 'remoteSourceUrl') return makeInput('https://example.com/video');
+        if (id === 'remoteDestinationFolder') return makeInput('/');
+        if (id === 'remoteAdvancedCommand') return makeInput('');
+        if (elements[id]) return elements[id];
+        return null;
+    }},
+    createElement() {{
+        return {{
+            className: '',
+            innerHTML: '',
+            style: {{}},
+            appendChild() {{}},
+            setAttribute() {{}},
+            textContent: ''
+        }};
+    }},
+    querySelectorAll() {{ return []; }}
+}};
+
+const context = {{
+    console: console,
+    document: documentStub,
+    window: {{
+        preservedSelections: null,
+        socketIOConfig: {{}},
+        currentFolder: '/',
+    }},
+    fetch: async () => ({{
+        ok: true,
+        headers: {{ get: () => 'application/json' }},
+        json: async () => ({{ job: {{ id: 'job-123' }} }})
+    }}),
+    setTimeout,
+    clearTimeout,
+    setInterval() {{ return 1; }},
+    clearInterval() {{}}
+}};
+
+context.window.window = context.window;
+context.window.jQuery = () => ({{
+    on() {{}},
+    modal() {{}}
+}});
+context.window.location = {{ origin: 'http://localhost' }};
+
+vm.createContext(context);
+vm.runInContext(code, context);
+
+console.log(JSON.stringify({{
+    formListeners,
+    buttonListeners,
+    resetCalled
+}}));
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output_line = completed.stdout.strip().splitlines()[-1]
+    data = json.loads(output_line)
+
+    assert 'submit' in data['formListeners']
+    assert 'click' in data['buttonListeners']
+    assert data['resetCalled'] is True


### PR DESCRIPTION
## Summary
- guard the remote import workflow so it only initializes once and still runs when the document is already ready
- add a node-based regression test that asserts the handlers are wired when the DOM is in a complete state

## Testing
- pytest tests/test_remote_import_initialization.py -q
- pytest tests/test_yt_dlp_jobs.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f51301b344832fbdaba29fd739210d