### PR TITLE
Normalize remote import URLs without schemes

### DIFF
--- a/app.py
+++ b/app.py
@@ -563,6 +563,11 @@ def _normalize_yt_dlp_inputs(payload: Dict[str, Any]) -> Dict[str, Any]:
             raise ValueError('url must be a string')
         normalized_url = url.strip()
 
+        if normalized_url.startswith('//'):
+            normalized_url = f'https:{normalized_url}'
+        elif '://' not in normalized_url:
+            normalized_url = f'https://{normalized_url.lstrip('/')}'
+
     if not normalized_url:
         raise ValueError('A URL must be supplied either via url or command')
 

--- a/static/upload.js
+++ b/static/upload.js
@@ -1003,6 +1003,46 @@ const REMOTE_IMPORT_ENDPOINT = '/api/yt-dlp/jobs';
 const REMOTE_IMPORT_STATUS_ENDPOINT = jobId => `/api/yt-dlp/jobs/${encodeURIComponent(jobId)}`;
 const REMOTE_IMPORT_POLL_INTERVAL_MS = 3000;
 
+function normalizeRemoteImportUrl(rawUrl) {
+    if (!rawUrl) {
+        return '';
+    }
+
+    let normalized = rawUrl.trim();
+    if (!normalized) {
+        return '';
+    }
+
+    if (/^\/\//.test(normalized)) {
+        normalized = `https:${normalized}`;
+    } else if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(normalized)) {
+        normalized = `https://${normalized}`;
+    }
+
+    return normalized;
+}
+
+function isHttpUrl(url) {
+    return /^https?:\/\//i.test(url);
+}
+
+function validateNormalizedRemoteUrl(url) {
+    if (!url) {
+        return false;
+    }
+
+    if (!isHttpUrl(url)) {
+        return false;
+    }
+
+    try {
+        const parsed = new URL(url);
+        return Boolean(parsed.hostname);
+    } catch (error) {
+        return false;
+    }
+}
+
 function getRemoteImportActivityCard() {
     return document.getElementById('remoteImportActivity');
 }
@@ -1475,8 +1515,27 @@ async function handleRemoteImportSubmit(event) {
         return false;
     }
 
+    const normalizedUrl = normalizeRemoteImportUrl(sourceUrl);
+
+    if (!validateNormalizedRemoteUrl(normalizedUrl)) {
+        if (elements.sourceInput) {
+            elements.sourceInput.classList.add('is-invalid');
+            const feedback = elements.sourceInput.parentElement ? elements.sourceInput.parentElement.querySelector('.invalid-feedback') : null;
+            if (feedback) {
+                feedback.textContent = 'Enter a valid http(s) URL.';
+            }
+        }
+        showStatus('Remote import requires a valid http(s) URL.', 'error');
+        appendRemoteImportLog('Remote import blocked: invalid URL provided.', 'error');
+        return false;
+    }
+
+    if (elements.sourceInput) {
+        elements.sourceInput.value = normalizedUrl;
+    }
+
     const payload = {
-        url: sourceUrl
+        url: normalizedUrl
     };
 
     const resolvedDestination = destinationFolder || (window.currentFolder && window.currentFolder.trim()) || '/';
@@ -1490,7 +1549,7 @@ async function handleRemoteImportSubmit(event) {
     remoteImportState.isSubmitting = true;
     toggleRemoteImportFormDisabled(true);
     showStatus('Submitting remote import request...', 'info');
-    appendRemoteImportLog(`Submitting remote import request for ${sourceUrl} → ${resolvedDestination}`, 'info');
+    appendRemoteImportLog(`Submitting remote import request for ${normalizedUrl} → ${resolvedDestination}`, 'info');
     remoteImportState.lastLoggedMessage = null;
     remoteImportState.lastLoggedProgressText = null;
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -90,7 +90,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                        <button type="submit" class="btn btn-primary" id="remoteImportSubmit">Start Import</button>
+                        <button type="submit" class="btn btn-primary" id="remoteImportSubmit" formnovalidate>Start Import</button>
                     </div>
                 </form>
             </div>

--- a/tests/test_remote_import_initialization.py
+++ b/tests/test_remote_import_initialization.py
@@ -10,6 +10,7 @@ def test_remote_import_initializes_when_dom_ready():
     node_script = f"""
 const fs = require('fs');
 const vm = require('vm');
+const {{ URL }} = require('url');
 
 const code = fs.readFileSync('{upload_js.as_posix()}', 'utf8');
 
@@ -141,3 +142,182 @@ console.log(JSON.stringify({{
     assert 'submit' in data['formListeners']
     assert 'click' in data['buttonListeners']
     assert data['resetCalled'] is True
+
+
+def test_remote_import_normalizes_scheme_before_submit():
+    project_root = Path(__file__).resolve().parents[1]
+    upload_js = project_root / "static" / "upload.js"
+
+    node_script = f"""
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('{upload_js.as_posix()}', 'utf8');
+
+const fetchCalls = [];
+
+function makeInput(initialValue = '') {{
+    return {{
+        value: initialValue,
+        disabled: false,
+        classList: {{
+            add() {{}},
+            remove() {{}}
+        }},
+        parentElement: {{
+            querySelector() {{
+                return {{
+                    textContent: '',
+                    innerHTML: ''
+                }};
+            }}
+        }}
+    }};
+}}
+
+const elements = {{
+    remoteImportForm: {{
+        reset() {{}},
+        addEventListener() {{}}
+    }},
+    remoteImportSubmit: {{
+        disabled: false,
+        addEventListener() {{}}
+    }},
+    remoteImportFormErrors: {{
+        classList: {{
+            add() {{}},
+            remove() {{}}
+        }},
+        textContent: ''
+    }},
+    remoteImportActivity: {{ style: {{ display: 'none' }} }},
+    remoteImportLog: {{
+        appendChild() {{}},
+        setAttribute() {{}},
+        children: [],
+        removeChild() {{}},
+        scrollTop: 0,
+        scrollHeight: 0
+    }},
+    remoteImportModal: {{
+        classList: {{
+            remove() {{}}
+        }},
+        setAttribute() {{}},
+        style: {{}},
+        querySelector() {{ return null; }}
+    }},
+    messageContainer: {{
+        innerHTML: '',
+        appendChild() {{}},
+        removeChild() {{}}
+    }}
+}};
+
+const inputs = {{
+    remoteSourceUrl: makeInput(''),
+    remoteDestinationFolder: makeInput('/'),
+    remoteAdvancedCommand: makeInput('')
+}};
+
+const documentStub = {{
+    readyState: 'complete',
+    body: {{
+        classList: {{
+            remove() {{}}
+        }}
+    }},
+    addEventListener() {{}},
+    getElementById(id) {{
+        if (id === 'remoteSourceUrl') return inputs.remoteSourceUrl;
+        if (id === 'remoteDestinationFolder') return inputs.remoteDestinationFolder;
+        if (id === 'remoteAdvancedCommand') return inputs.remoteAdvancedCommand;
+        if (elements[id]) return elements[id];
+        return null;
+    }},
+    createElement() {{
+        return {{
+            className: '',
+            innerHTML: '',
+            style: {{}},
+            appendChild() {{}},
+            setAttribute() {{}},
+            textContent: '',
+            classList: {{ add() {{}}, remove() {{}} }}
+        }};
+    }},
+    querySelector() {{ return null; }},
+    querySelectorAll() {{ return []; }}
+}};
+
+const context = {{
+    console: console,
+    document: documentStub,
+    window: {{
+        preservedSelections: null,
+        socketIOConfig: {{}},
+        currentFolder: '/',
+        URL: URL,
+    }},
+    fetch: async (url, options = {{}}) => {{
+        fetchCalls.push({{ url, body: options.body }});
+        return {{
+            ok: true,
+            headers: {{ get: () => 'application/json' }},
+            json: async () => ({{ job: {{ id: 'job-789' }} }})
+        }};
+    }},
+    setTimeout,
+    clearTimeout,
+    setInterval() {{ return 1; }},
+    clearInterval() {{}},
+    URL: URL
+}};
+
+context.window.window = context.window;
+context.window.jQuery = () => ({{
+    on() {{}},
+    modal() {{}}
+}});
+
+vm.createContext(context);
+vm.runInContext(code, context);
+
+context.toggleRemoteImportFormDisabled = () => {{}};
+context.closeRemoteImportModal = () => {{}};
+context.resetRemoteImportForm = () => {{}};
+context.startRemoteImportTracking = () => {{}};
+
+if (context.window.__remoteImport) {{
+    context.window.__remoteImport.startRemoteImportTracking = () => {{}};
+}}
+
+inputs.remoteSourceUrl.value = 'example.com/video';
+
+context.window.handleRemoteImportSubmit({{
+    preventDefault() {{}}
+}});
+
+const normalizedValue = inputs.remoteSourceUrl.value;
+const body = fetchCalls.length ? fetchCalls[0].body : null;
+
+console.log(JSON.stringify({{
+    normalizedValue,
+    body
+}}));
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output_line = completed.stdout.strip().splitlines()[-1]
+    data = json.loads(output_line)
+
+    assert data['normalizedValue'] == 'https://example.com/video'
+    payload = json.loads(data['body'])
+    assert payload['url'] == 'https://example.com/video'

--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -160,6 +160,17 @@ def test_create_job_requires_url():
     assert 'error' in resp.get_json()
 
 
+def test_create_job_accepts_url_without_scheme():
+    client = flask_app.app.test_client()
+
+    resp = client.post('/api/yt-dlp/jobs', json={'url': 'example.com/video'})
+
+    assert resp.status_code == 201
+    payload = resp.get_json()['job']
+    assert payload['url'] == 'https://example.com/video'
+    assert payload['normalized_command'].endswith('https://example.com/video')
+
+
 def test_build_command_places_output_before_url(tmp_path):
     importer = importer_module.YtDlpImporter(upload_manager=None, job_registry=None)
     normalized_command = (


### PR DESCRIPTION
## Summary
- ensure the remote import modal allows submissions without native URL validation blocking the button
- normalize missing schemes to https on the client and server before dispatching yt-dlp jobs
- extend the automated tests to cover the new URL handling behaviour in both the Flask endpoint and frontend script

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f51873fd08832f87705c28e4fa2ff1