### PR TITLE
Fix URL normalization quoting issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -566,7 +566,7 @@ def _normalize_yt_dlp_inputs(payload: Dict[str, Any]) -> Dict[str, Any]:
         if normalized_url.startswith('//'):
             normalized_url = f'https:{normalized_url}'
         elif '://' not in normalized_url:
-            normalized_url = f'https://{normalized_url.lstrip('/')}'
+            normalized_url = f"https://{normalized_url.lstrip('/')}"
 
     if not normalized_url:
         raise ValueError('A URL must be supplied either via url or command')


### PR DESCRIPTION
## Summary
- correct the f-string used when prefixing normalized URLs with https to avoid invalid string delimiters

## Testing
- pytest *(fails: missing boto3 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68f51d819e20832f92b971fcd1a6805a