### PR TITLE
Add yt-dlp preflight checks and surface remote import errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -612,6 +612,79 @@ def _normalize_yt_dlp_inputs(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _run_yt_dlp_preflight_checks(user_id: Optional[str]) -> tuple[Dict[str, Any], List[str]]:
+    """Evaluate the prerequisites for running a yt-dlp import."""
+
+    checks: Dict[str, Any] = {
+        'yt_dlp_executable': {
+            'status': 'unknown',
+            'detail': None,
+        },
+        'notion_database': {
+            'status': 'unknown',
+            'detail': None,
+        },
+        'temporary_directory': {
+            'status': 'unknown',
+            'detail': None,
+        },
+    }
+    errors: List[str] = []
+
+    executable = 'yt-dlp'
+    executable_path = shutil.which(executable)
+    if executable_path:
+        checks['yt_dlp_executable']['status'] = 'ok'
+        checks['yt_dlp_executable']['detail'] = executable_path
+    else:
+        msg = (
+            f"Executable '{executable}' is not available on the server. "
+            'Install yt-dlp or adjust PATH before importing from a remote URL.'
+        )
+        checks['yt_dlp_executable']['status'] = 'error'
+        checks['yt_dlp_executable']['detail'] = msg
+        errors.append(msg)
+
+    database_id: Optional[str] = None
+    if user_id:
+        try:
+            database_id = uploader.get_user_database_id(user_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception('Failed to resolve Notion database for user %s', user_id)
+            msg = f'Unable to resolve Notion database for the current user: {exc}'
+            checks['notion_database']['status'] = 'error'
+            checks['notion_database']['detail'] = msg
+            errors.append(msg)
+        else:
+            if database_id:
+                checks['notion_database']['status'] = 'ok'
+                checks['notion_database']['detail'] = database_id
+            else:
+                msg = 'No Notion database is associated with the current user.'
+                checks['notion_database']['status'] = 'error'
+                checks['notion_database']['detail'] = msg
+                errors.append(msg)
+    else:
+        msg = 'No authenticated user is associated with this request.'
+        checks['notion_database']['status'] = 'error'
+        checks['notion_database']['detail'] = msg
+        errors.append(msg)
+
+    try:
+        with tempfile.NamedTemporaryFile(prefix='yt-dlp-preflight-', delete=True) as tmp_file:
+            tmp_file.write(b'check')
+            tmp_file.flush()
+        checks['temporary_directory']['status'] = 'ok'
+        checks['temporary_directory']['detail'] = tempfile.gettempdir()
+    except Exception as exc:
+        msg = f'Unable to write to the temporary directory: {exc}'
+        checks['temporary_directory']['status'] = 'error'
+        checks['temporary_directory']['detail'] = msg
+        errors.append(msg)
+
+    return checks, errors
+
+
 def _execute_yt_dlp_job(job_id: str) -> None:
     yt_dlp_importer.execute(job_id, _parse_yt_dlp_progress)
 
@@ -3298,6 +3371,25 @@ def get_upload_status(upload_id):
 @login_required
 def list_yt_dlp_jobs():
     return jsonify({'jobs': yt_dlp_job_registry.list()})
+
+
+@app.route('/api/yt-dlp/preflight', methods=['GET'])
+@login_required
+def get_yt_dlp_preflight_status():
+    user_id = getattr(current_user, 'id', None)
+    checks, errors = _run_yt_dlp_preflight_checks(user_id)
+
+    response_payload = {
+        'status': 'ok' if not errors else 'error',
+        'checks': checks,
+    }
+
+    if errors:
+        response_payload['message'] = ' '.join(errors)
+        return jsonify(response_payload), 503
+
+    response_payload['message'] = 'All yt-dlp preflight checks passed.'
+    return jsonify(response_payload)
 
 
 def _redact_yt_dlp_payload(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/static/upload.js
+++ b/static/upload.js
@@ -1000,6 +1000,7 @@ const uploadFile = async () => {
 // ---------------------------------------------------------------------------
 
 const REMOTE_IMPORT_ENDPOINT = '/api/yt-dlp/jobs';
+const REMOTE_IMPORT_PREFLIGHT_ENDPOINT = '/api/yt-dlp/preflight';
 const REMOTE_IMPORT_STATUS_ENDPOINT = jobId => `/api/yt-dlp/jobs/${encodeURIComponent(jobId)}`;
 const REMOTE_IMPORT_POLL_INTERVAL_MS = 3000;
 
@@ -1107,7 +1108,10 @@ const remoteImportState = {
     socketSubscribedJobId: null,
     lastLoggedMessage: null,
     lastLoggedProgressText: null,
-    initialized: false
+    initialized: false,
+    formLocked: false,
+    preflightPassed: false,
+    activeErrorMessage: null
 };
 
 function getRemoteImportElements() {
@@ -1121,8 +1125,44 @@ function getRemoteImportElements() {
     };
 }
 
+function updateRemoteImportErrorAlert(message, { append = false } = {}) {
+    const { errorAlert } = getRemoteImportElements();
+    if (!errorAlert) {
+        return '';
+    }
+
+    const trimmedMessage = typeof message === 'string' ? message.trim() : '';
+    if (!trimmedMessage) {
+        errorAlert.classList.add('d-none');
+        errorAlert.textContent = '';
+        return '';
+    }
+
+    const existing = (errorAlert.textContent || '').trim();
+    const combined = append && existing ? `${existing}\n${trimmedMessage}` : trimmedMessage;
+    errorAlert.classList.remove('d-none');
+    errorAlert.textContent = combined;
+    return combined;
+}
+
+function setRemoteImportSubmitDisabled(isDisabled) {
+    const { submitButton } = getRemoteImportElements();
+    if (submitButton) {
+        submitButton.disabled = Boolean(isDisabled);
+    }
+}
+
+function clearRemoteImportErrors() {
+    remoteImportState.activeErrorMessage = null;
+    updateRemoteImportErrorAlert('');
+
+    if (!remoteImportState.formLocked) {
+        setRemoteImportSubmitDisabled(!remoteImportState.preflightPassed);
+    }
+}
+
 function resetRemoteImportValidation() {
-    const { sourceInput, destinationInput, commandInput, errorAlert } = getRemoteImportElements();
+    const { sourceInput, destinationInput, commandInput } = getRemoteImportElements();
     [sourceInput, destinationInput, commandInput].forEach(input => {
         if (input) {
             input.classList.remove('is-invalid');
@@ -1133,13 +1173,12 @@ function resetRemoteImportValidation() {
         }
     });
 
-    if (errorAlert) {
-        errorAlert.classList.add('d-none');
-        errorAlert.textContent = '';
-    }
+    remoteImportState.formLocked = false;
+    clearRemoteImportErrors();
+    toggleRemoteImportFormDisabled(false);
 }
 
-function applyRemoteImportErrors(errorData) {
+function applyRemoteImportErrors(errorData, { lockForm = false, appendToAlert = false } = {}) {
     const elements = getRemoteImportElements();
     const fieldErrors = (errorData && (errorData.field_errors || errorData.errors)) || {};
     const generalMessages = [];
@@ -1174,15 +1213,24 @@ function applyRemoteImportErrors(errorData) {
         generalMessages.push(fieldErrors.join(' '));
     }
 
-    if (elements.errorAlert && generalMessages.length > 0) {
-        elements.errorAlert.classList.remove('d-none');
-        elements.errorAlert.textContent = generalMessages.join(' ');
+    const combinedMessage = generalMessages.join(' ').trim();
+    if (combinedMessage) {
+        const messageShown = updateRemoteImportErrorAlert(combinedMessage, { append: appendToAlert });
+        remoteImportState.activeErrorMessage = messageShown;
+        showStatus(combinedMessage, 'error');
+        appendRemoteImportLog(combinedMessage, 'error');
     }
 
-    if (generalMessages.length > 0) {
-        showStatus(generalMessages.join(' '), 'error');
-        appendRemoteImportLog(generalMessages.join(' '), 'error');
+    if (lockForm) {
+        remoteImportState.formLocked = true;
     }
+
+    if (remoteImportState.formLocked) {
+        toggleRemoteImportFormDisabled(true);
+        setRemoteImportSubmitDisabled(true);
+    }
+
+    return combinedMessage;
 }
 
 function toggleRemoteImportFormDisabled(isDisabled) {
@@ -1192,6 +1240,50 @@ function toggleRemoteImportFormDisabled(isDisabled) {
             input.disabled = isDisabled;
         }
     });
+}
+
+async function runRemoteImportPreflight() {
+    const elements = getRemoteImportElements();
+    if (!elements.submitButton) {
+        return false;
+    }
+
+    try {
+        const response = await fetch(REMOTE_IMPORT_PREFLIGHT_ENDPOINT, {
+            method: 'GET',
+            credentials: 'include'
+        });
+
+        const contentType = response.headers.get('content-type') || '';
+        const isJson = contentType.includes('application/json');
+        const data = isJson ? await response.json() : null;
+
+        if (!response.ok || !data || data.status !== 'ok') {
+            const message = (data && (data.message || data.error || data.detail)) || 'Remote import preflight failed.';
+            remoteImportState.preflightPassed = false;
+            setRemoteImportSubmitDisabled(true);
+            const shown = updateRemoteImportErrorAlert(message, { append: false });
+            remoteImportState.activeErrorMessage = shown;
+            return false;
+        }
+
+        remoteImportState.preflightPassed = true;
+        if (!remoteImportState.formLocked) {
+            setRemoteImportSubmitDisabled(false);
+            if (!remoteImportState.activeErrorMessage) {
+                updateRemoteImportErrorAlert('');
+            }
+        }
+
+        return true;
+    } catch (error) {
+        console.error('Remote import preflight failed:', error);
+        remoteImportState.preflightPassed = false;
+        setRemoteImportSubmitDisabled(true);
+        const shown = updateRemoteImportErrorAlert(`Remote import preflight failed: ${error.message}`, { append: false });
+        remoteImportState.activeErrorMessage = shown;
+        return false;
+    }
 }
 
 function resetRemoteImportForm() {
@@ -1553,6 +1645,8 @@ async function handleRemoteImportSubmit(event) {
     remoteImportState.lastLoggedMessage = null;
     remoteImportState.lastLoggedProgressText = null;
 
+    let shouldUnlockForm = true;
+
     try {
         const response = await fetch(REMOTE_IMPORT_ENDPOINT, {
             method: 'POST',
@@ -1568,7 +1662,11 @@ async function handleRemoteImportSubmit(event) {
         const data = hasJson ? await response.json() : null;
 
         if (!response.ok) {
-            applyRemoteImportErrors(data || { message: 'The server rejected the import request.' });
+            shouldUnlockForm = false;
+            applyRemoteImportErrors(
+                data || { message: 'The server rejected the import request.' },
+                { lockForm: true, appendToAlert: true }
+            );
             return false;
         }
 
@@ -1588,11 +1686,21 @@ async function handleRemoteImportSubmit(event) {
         startRemoteImportTracking(jobId, jobPayload);
     } catch (error) {
         console.error('Remote import submission failed:', error);
-        showStatus(`Failed to start remote import: ${error.message}`, 'error');
-        appendRemoteImportLog(`Failed to start remote import: ${error.message}`, 'error');
+        shouldUnlockForm = false;
+        applyRemoteImportErrors(
+            { message: `Failed to start remote import: ${error.message}` },
+            { lockForm: true, appendToAlert: true }
+        );
     } finally {
         remoteImportState.isSubmitting = false;
-        toggleRemoteImportFormDisabled(false);
+        if (shouldUnlockForm) {
+            toggleRemoteImportFormDisabled(false);
+            setRemoteImportSubmitDisabled(!remoteImportState.preflightPassed);
+        } else {
+            remoteImportState.formLocked = true;
+            toggleRemoteImportFormDisabled(true);
+            setRemoteImportSubmitDisabled(true);
+        }
     }
 
     return false;
@@ -1627,6 +1735,7 @@ function initializeRemoteImportWorkflow() {
             if (destinationInput) {
                 destinationInput.value = (window.currentFolder && window.currentFolder.trim()) ? window.currentFolder : '/';
             }
+            runRemoteImportPreflight();
         };
 
         const onHidden = () => {
@@ -1643,6 +1752,8 @@ function initializeRemoteImportWorkflow() {
             modalElement.addEventListener('hidden.bs.modal', onHidden);
         }
     }
+
+    runRemoteImportPreflight();
 }
 
 function runWhenDocumentReady(callback) {

--- a/tests/test_yt_dlp_jobs.py
+++ b/tests/test_yt_dlp_jobs.py
@@ -83,6 +83,13 @@ def disable_login(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def stub_current_user(monkeypatch):
+    dummy_user = SimpleNamespace(id='test-user', is_authenticated=True)
+    monkeypatch.setattr(flask_app, 'current_user', dummy_user)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def clear_job_registry():
     with flask_app.yt_dlp_job_registry._lock:  # pylint: disable=protected-access
         flask_app.yt_dlp_job_registry._jobs.clear()  # pylint: disable=protected-access
@@ -158,6 +165,67 @@ def test_create_job_requires_url():
     resp = client.post('/api/yt-dlp/jobs', json={})
     assert resp.status_code == 400
     assert 'error' in resp.get_json()
+
+
+def test_preflight_success():
+    client = flask_app.app.test_client()
+    resp = client.get('/api/yt-dlp/preflight')
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload['status'] == 'ok'
+    assert payload['checks']['yt_dlp_executable']['status'] == 'ok'
+    assert payload['checks']['notion_database']['status'] == 'ok'
+    assert payload['checks']['temporary_directory']['status'] == 'ok'
+
+
+def test_preflight_missing_executable(monkeypatch):
+    client = flask_app.app.test_client()
+
+    monkeypatch.setattr(flask_app.shutil, 'which', lambda exe: None)
+
+    resp = client.get('/api/yt-dlp/preflight')
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload['status'] == 'error'
+    assert "Executable 'yt-dlp'" in payload['message']
+    assert payload['checks']['yt_dlp_executable']['status'] == 'error'
+
+
+def test_preflight_missing_database(monkeypatch):
+    client = flask_app.app.test_client()
+
+    monkeypatch.setattr(flask_app.uploader, 'get_user_database_id', lambda user_id: None)
+
+    resp = client.get('/api/yt-dlp/preflight')
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload['status'] == 'error'
+    assert 'No Notion database' in payload['message']
+    assert payload['checks']['notion_database']['status'] == 'error'
+
+
+def test_preflight_temp_directory_failure(monkeypatch):
+    client = flask_app.app.test_client()
+
+    class FailingTempFile:
+        def __enter__(self):
+            raise PermissionError('denied')
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(flask_app.tempfile, 'NamedTemporaryFile', lambda *args, **kwargs: FailingTempFile())
+
+    resp = client.get('/api/yt-dlp/preflight')
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload['status'] == 'error'
+    assert 'temporary directory' in payload['message']
+    assert payload['checks']['temporary_directory']['status'] == 'error'
 
 
 def test_create_job_accepts_url_without_scheme():


### PR DESCRIPTION
## Summary
- add a /api/yt-dlp/preflight endpoint that verifies yt-dlp availability, Notion database access, and temp-directory writes
- call the preflight check from the remote import UI, surface server errors, and lock the form until the issue is cleared
- add automated coverage for the new preflight scenarios

## Testing
- pytest tests/test_yt_dlp_jobs.py -k preflight

------
https://chatgpt.com/codex/tasks/task_e_68f673cc28ec832fbc5e7b4f3bac6098