### PR TITLE
Allow remote import form recovery after user errors

### DIFF
--- a/static/upload.js
+++ b/static/upload.js
@@ -1662,10 +1662,13 @@ async function handleRemoteImportSubmit(event) {
         const data = hasJson ? await response.json() : null;
 
         if (!response.ok) {
-            shouldUnlockForm = false;
+            const isServerError = response.status >= 500;
+            if (isServerError) {
+                shouldUnlockForm = false;
+            }
             applyRemoteImportErrors(
                 data || { message: 'The server rejected the import request.' },
-                { lockForm: true, appendToAlert: true }
+                { lockForm: isServerError, appendToAlert: true }
             );
             return false;
         }


### PR DESCRIPTION
## Summary
- keep the remote import form unlocked when the yt-dlp request returns user-fixable errors
- only lock and disable the form when the request fails with server-side errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f699ded28c832f967b8c3365b3b250