### PR TITLE
Clarify default upload concurrency fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,6 +217,32 @@ def cleanup_old_sessions():
 # Load environment variables from .env file
 load_dotenv()
 
+
+DEFAULT_MAX_CONCURRENT_UPLOADS = 3
+
+
+def _get_positive_int_from_env(var_name: str, default: int) -> int:
+    """Return a positive integer from the environment or a default."""
+
+    raw_value = os.environ.get(var_name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(str(raw_value).strip())
+    except (TypeError, ValueError):
+        print(f"Invalid value for {var_name!r}: {raw_value!r}. Using default {default}.")
+        return default
+
+    if value <= 0:
+        print(f"Non-positive value for {var_name!r}: {raw_value!r}. Using default {default}.")
+        return default
+
+    return value
+
+
+MAX_CONCURRENT_UPLOADS = _get_positive_int_from_env('MAX_CONCURRENT_UPLOADS', DEFAULT_MAX_CONCURRENT_UPLOADS)
+
 app = Flask(__name__)
 # Use a safe default for development if SECRET_KEY is not provided
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret-key')
@@ -739,7 +765,15 @@ def home():
                 next_cursor = 0
                 last_sync = 0
             refresh_cache_async(user_database_id)
-        return render_template('home.html', entries=entries, current_folder=current_folder, next_cursor=next_cursor, cache_timestamp=last_sync)
+        return render_template(
+            'home.html',
+            entries=entries,
+            current_folder=current_folder,
+            next_cursor=next_cursor,
+            cache_timestamp=last_sync,
+            max_concurrent_uploads=MAX_CONCURRENT_UPLOADS,
+            default_max_concurrent_uploads=DEFAULT_MAX_CONCURRENT_UPLOADS,
+        )
     except Exception as e:
         return f"Error loading home page: {str(e)}", 500
 

--- a/static/streaming-upload.js
+++ b/static/streaming-upload.js
@@ -10,6 +10,39 @@ window.pendingUploads = window.pendingUploads || new Set();
 const PENDING_UPLOAD_POLL_INTERVAL_MS = 2000;
 const UPLOAD_HEARTBEAT_INTERVAL_MS = 20000;
 const FILE_SYNC_INTERVAL_MS = 30000;
+const DEFAULT_MAX_CONCURRENT_UPLOADS = (() => {
+    const configDefaults = window.uploadConfig?.defaults;
+    const rawDefault = configDefaults?.maxConcurrentUploads;
+    const parsedDefault = Number(rawDefault);
+
+    if (Number.isFinite(parsedDefault) && parsedDefault > 0) {
+        return Math.floor(parsedDefault);
+    }
+
+    return 3;
+})();
+
+function getConfiguredMaxConcurrentUploads() {
+    const config = window.uploadConfig || {};
+    const rawValue = config.maxConcurrentUploads;
+
+    if (rawValue === undefined || rawValue === null) {
+        return DEFAULT_MAX_CONCURRENT_UPLOADS;
+    }
+
+    const parsed = Number(rawValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return Math.floor(parsed);
+    }
+
+    console.warn(
+        'Invalid maxConcurrentUploads value provided:',
+        rawValue,
+        'Using default of',
+        DEFAULT_MAX_CONCURRENT_UPLOADS
+    );
+    return DEFAULT_MAX_CONCURRENT_UPLOADS;
+}
 
 function ensurePendingUploadState() {
     if (!window.__pendingUploadState) {
@@ -925,7 +958,7 @@ const uploadFile = async () => {
         elements: createProgressBarElements(file.name, file.size)
     }));
 
-    const maxConcurrent = 3;
+    const maxConcurrent = getConfiguredMaxConcurrentUploads();
     const executing = [];
     const allUploads = [];
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -210,6 +210,19 @@
     window.cacheTimestamp = {{ cache_timestamp or 0 }};
     window.cachedEntries = {{ entries | tojson }};
 </script>
+<script>
+    window.uploadConfig = Object.assign(
+        {
+            defaults: {
+                maxConcurrentUploads: {{ default_max_concurrent_uploads | tojson }}
+            }
+        },
+        window.uploadConfig,
+        {
+            maxConcurrentUploads: {{ max_concurrent_uploads | tojson }}
+        }
+    );
+</script>
 <script src="{{ url_for('static', filename='streaming-upload.js') }}"></script>
 
 <script>


### PR DESCRIPTION
## Summary
- define a shared DEFAULT_MAX_CONCURRENT_UPLOADS constant so the server retains a clear fallback when the environment variable is missing or invalid
- expose both the configured and default concurrency values to the upload template so the front end can access the fallback value
- update the streaming upload script to read the default from configuration while preserving a safe hard-coded fallback

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'boto3')*


------
https://chatgpt.com/codex/tasks/task_e_68fbbf5cb988832fabda70b273cb7d64