### PR TITLE
Fix folder links to preserve special characters

### DIFF
--- a/app.py
+++ b/app.py
@@ -389,6 +389,19 @@ def _get_folder_from_request(default: str = '/') -> str:
     return folder or default
 
 
+@app.template_filter('encode_query_component')
+def encode_query_component(value: Any) -> str:
+    """URL-encode a query component while preserving slashes."""
+
+    if value is None:
+        return ''
+
+    if not isinstance(value, str):
+        value = str(value)
+
+    return quote(value, safe='/')
+
+
 _HTTP_STATUS_RE = re.compile(r"HTTP\s+(\d{3})")
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,9 +9,10 @@
         <strong>Current Folder:</strong> {{ current_folder }}
         {% if current_folder != '/' %}
             {% set parent_folder = '/' + '/'.join(current_folder.strip('/').split('/')[:-1]) %}
-            <a href="{{ url_for('home', folder=parent_folder if parent_folder != '//' else '/') }}" class="ml-2">Back</a>
+            {% set parent_target = parent_folder if parent_folder not in ('', '//') else '/' %}
+            <a href="{{ url_for('home') }}?folder={{ parent_target | encode_query_component }}" class="ml-2">Back</a>
         {% endif %}
-        <a href="{{ url_for('download_folder', folder=current_folder) }}" class="btn btn-primary btn-sm ml-2">
+        <a href="{{ url_for('download_folder') }}?folder={{ current_folder | encode_query_component }}" class="btn btn-primary btn-sm ml-2">
             <i class="fas fa-download mr-1"></i>Download Folder
         </a>
         <button id="createFolderButton" class="btn btn-secondary btn-sm ml-2">
@@ -75,10 +76,10 @@
                         <td class="public-link-column"></td>
                         <td class="public-access-column"></td>
                         <td>
-                            <a href="{{ url_for('home', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
+                            <a href="{{ url_for('home') }}?folder={{ entry.full_path | encode_query_component }}" class="btn btn-primary btn-sm">
                                 <i class="fas fa-folder-open mr-1"></i>Open
                             </a>
-                            <a href="{{ url_for('download_folder', folder=entry.full_path) }}" class="btn btn-primary btn-sm">
+                            <a href="{{ url_for('download_folder') }}?folder={{ entry.full_path | encode_query_component }}" class="btn btn-primary btn-sm">
                                 <i class="fas fa-download mr-1"></i>Download
                             </a>
                             <button class="btn btn-secondary btn-sm rename-folder-btn" data-folder-id="{{ entry.id }}" data-folder-name="{{ entry.name }}">

--- a/tests/test_folder_query_parsing.py
+++ b/tests/test_folder_query_parsing.py
@@ -5,7 +5,7 @@ _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if _ROOT not in sys.path:
     sys.path.insert(0, _ROOT)
 
-from app import app, _get_folder_from_request
+from app import app, _get_folder_from_request, encode_query_component
 
 
 def test_get_folder_from_request_preserves_semicolons():
@@ -16,3 +16,11 @@ def test_get_folder_from_request_preserves_semicolons():
 def test_get_folder_from_request_default_root():
     with app.test_request_context('/'):
         assert _get_folder_from_request() == '/'
+
+
+def test_encode_query_component_preserves_semicolons():
+    assert encode_query_component('/series/Steins;Gate') == '/series/Steins%3BGate'
+
+
+def test_encode_query_component_handles_root():
+    assert encode_query_component('/') == '/'


### PR DESCRIPTION
## Summary
- add a reusable `encode_query_component` Jinja filter that percent-encodes query values while preserving slashes
- update folder navigation and download links to use the encoded query values so names containing semicolons remain intact
- extend the folder query parsing tests to cover the new encoding helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690728a02b50832fbc8a60be4451dc44